### PR TITLE
New v4.1.2 created automatically from CircleCI

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,4 +1,7 @@
 {
+  "git": {
+    "commitMessage": "chore(release): ${version}"
+  },
   "github": {
     "tokenRef": "GH_TOKEN"
   },

--- a/README/authentication.md
+++ b/README/authentication.md
@@ -134,6 +134,7 @@ DynamicApiModule.forRoot('mongodb-uri', {
         enabled: boolean | ((data: Partial<Entity>, user?: any) => boolean);
         eventName?: string;                   // Default: 'auth-login-broadcast'
         fields?: (keyof Entity)[];            // Fields to include (default: all)
+        rooms?: string | string[] | ((data: Partial<Entity>) => string | string[]); // Target rooms
       };
       /**
        * Optional async function called before the Passport local strategy validates credentials.
@@ -156,6 +157,7 @@ DynamicApiModule.forRoot('mongodb-uri', {
         enabled: boolean | ((data: Partial<Entity>, user?: any) => boolean);
         eventName?: string;                   // Default: 'auth-get-account-broadcast'
         fields?: (keyof Entity)[];            // Fields to include (default: all)
+        rooms?: string | string[] | ((data: Partial<Entity>) => string | string[]); // Target rooms
       };
     },
     
@@ -171,6 +173,7 @@ DynamicApiModule.forRoot('mongodb-uri', {
         enabled: boolean | ((data: Partial<Entity>, user?: any) => boolean);
         eventName?: string;                   // Default: 'auth-register-broadcast'
         fields?: (keyof Entity)[];            // Fields to include (default: all)
+        rooms?: string | string[] | ((data: Partial<Entity>) => string | string[]); // Target rooms
       };
     },
     
@@ -185,6 +188,7 @@ DynamicApiModule.forRoot('mongodb-uri', {
         enabled: boolean | ((data: Partial<Entity>, user?: any) => boolean);
         eventName?: string;                   // Default: 'auth-update-account-broadcast'
         fields?: (keyof Entity)[];            // Fields to include (default: all)
+        rooms?: string | string[] | ((data: Partial<Entity>) => string | string[]); // Target rooms
       };
     },
     
@@ -1085,6 +1089,7 @@ type AuthBroadcastConfig<Entity> = {
   enabled: boolean | BroadcastAbilityPredicate<Partial<Entity>>;
   eventName?: string;
   fields?: (keyof Entity)[];
+  rooms?: BroadcastRooms<Partial<Entity>>;
 };
 ```
 
@@ -1093,6 +1098,7 @@ type AuthBroadcastConfig<Entity> = {
 | `enabled` | `boolean \| (data, user?) => boolean` | ✅ Yes | `true` = always broadcast · `false` = never broadcast · function = conditional broadcast evaluated with the data about to be broadcast |
 | `eventName` | `string` | ❌ No | Custom broadcast event name. Defaults to the standard name (see table below) |
 | `fields` | `(keyof Entity)[]` | ❌ No | List of fields to include in the broadcast payload. If omitted or empty, **all available fields** from the data source are broadcast |
+| `rooms` | `string \| string[] \| (data) => string \| string[]` | ❌ No | Target specific Socket.IO rooms. If set, only clients that joined the specified room(s) receive the broadcast. If omitted, all connected clients receive it. See [Room-Targeted Broadcasting](./websockets.md#room-targeted-broadcasting) |
 
 ### Default Broadcast Event Names
 
@@ -1229,6 +1235,64 @@ DynamicApiModule.forRoot('mongodb://localhost:27017/myapp', {
   },
 })
 ```
+
+#### Room-Targeted Auth Broadcasts
+
+You can restrict auth broadcasts to specific Socket.IO rooms using `rooms`. Clients must have joined the target room via the `join-rooms` event to receive the broadcast:
+
+```typescript
+DynamicApiModule.forRoot('mongodb://localhost:27017/myapp', {
+  useAuth: {
+    userEntity: User,
+    login: {
+      additionalFields: ['role', 'department'],
+      broadcast: {
+        enabled: true,
+        fields: ['id', 'email', 'role', 'department'],
+        // Dynamic room — broadcast login events only to the user's department
+        rooms: (user) => `department-${user.department}`,
+      },
+    },
+    register: {
+      broadcast: {
+        enabled: true,
+        fields: ['id', 'email'],
+        rooms: 'admin-dashboard', // Static room — only admin dashboard clients see registrations
+      },
+    },
+    updateAccount: {
+      broadcast: {
+        enabled: true,
+        fields: ['id', 'email', 'name'],
+        // Broadcast to multiple static rooms
+        rooms: ['admin-dashboard', 'user-directory'],
+      },
+    },
+  },
+})
+```
+
+**Client-side with rooms:**
+
+```typescript
+const socket = io('http://localhost:3000', {
+  auth: { token: accessToken },
+});
+
+// Admin joins the admin-dashboard room
+socket.emit('join-rooms', { rooms: 'admin-dashboard' }, (res) => {
+  console.log('Joined:', res.data); // ['admin-dashboard']
+});
+
+// Now this client receives registration broadcasts
+socket.on('auth-register-broadcast', (data) => {
+  console.log('New user registered:', data); // [{ id, email }]
+});
+
+// A regular user who did NOT join 'admin-dashboard' will NOT see registrations
+```
+
+> For full details on room management (`join-rooms`, `leave-rooms`, static vs dynamic rooms), see the [Room-Targeted Broadcasting](./websockets.md#room-targeted-broadcasting) section in the WebSockets documentation.
 
 ### Client-Side: Listening for Broadcast Events
 

--- a/README/authentication.md
+++ b/README/authentication.md
@@ -315,6 +315,8 @@ Authenticate and receive a JWT token.
 }
 ```
 
+> **💡 Alias:** You can send `login` instead of the configured `loginField` name. For example, `{ "login": "john.doe@example.com", "password": "..." }` is equivalent to `{ "email": "john.doe@example.com", "password": "..." }` when `loginField` is `'email'`. MDA maps `body.login` → `body[loginField]` automatically if `body[loginField]` is not already present.
+
 **Response (200 OK):**
 ```json
 {
@@ -356,6 +358,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
   "updatedAt": "2026-02-21T10:30:00.000Z"
 }
 ```
+
+> **🔒 Security Note:** The `id` used to fetch the account is **derived exclusively from the JWT access token** (`req.user`). The server decodes the token, extracts `sub` (mapped to `id`), then performs `findOne({ _id: id })` against the database. This means:
+>
+> - A user **cannot** access another user's account by manipulating request parameters — the `_id` always comes from the signed token.
+> - If the JWT has been tampered with, verification fails and the request is rejected with `401 Unauthorized`.
+ > - There is **no mixing of accounts**: the returned data always belongs to the token owner.
 
 ### 4. Update Account
 
@@ -629,6 +637,43 @@ customValidate?: (req: Request) => Promise<Entity | null>
 - Receives the full Express `Request` object.
 - Return a `User` entity to authenticate immediately (no password check).
 - Return `null` to fall through to the standard `validateUser(login, password)` logic.
+
+#### Return `null` = Fallback to Standard Validation
+
+When `customValidate` returns `null`, MDA proceeds **exactly** as if `customValidate` was not defined — it calls `validateUser(login, password)` with the credentials from the request body. This means you can use `customValidate` as an **optional fast-path** without preventing normal password login:
+
+```typescript
+customValidate: async (req) => {
+  const deviceToken = req.headers['x-device-token'] as string;
+  if (!deviceToken) return null; // ← null = fall through to email/password
+
+  return DeviceTokenService.findUserByToken(deviceToken);
+},
+```
+
+#### `req.body` Shape and the `login` Alias
+
+Inside `customValidate`, `req.body` contains the raw JSON body sent by the client. Typically this includes the configured `loginField` and `passwordField`:
+
+```typescript
+// With default loginField='email', passwordField='password':
+// req.body = { email: 'john@example.com', password: 'secret' }
+
+// With loginField='username':
+// req.body = { username: 'john', password: 'secret' }
+```
+
+**`body.login` alias:** Clients can send `{ login: 'john@example.com', password: 'secret' }` instead of `{ email: 'john@example.com', password: 'secret' }`. Before `customValidate` (and before Passport's own `validate`) is called, MDA automatically maps `req.body.login` → `req.body[loginField]` if `body[loginField]` is not already present. This makes the API more user-friendly when the login field name varies between deployments:
+
+```typescript
+// Client sends: { login: 'john@example.com', password: 'secret' }
+// MDA rewrites to: { email: 'john@example.com', login: 'john@example.com', password: 'secret' }
+// → customValidate receives req.body.email = 'john@example.com'
+```
+
+#### Bypassing Passport's "Missing credentials" Error
+
+Passport-local normally rejects requests with a `401 Unauthorized` ("Missing credentials") if `username` or `password` are falsy in the body — **before** calling the `validate` callback. When `customValidate` is defined, MDA overrides Passport's `authenticate` method to skip this check, ensuring `customValidate` is always reached even when the body is empty or lacks credentials. This is critical for passwordless flows (e.g., device tokens, magic links) where `email`/`password` may not be present at all.
 
 **Example — Magic-link / device token login:**
 

--- a/README/websockets.md
+++ b/README/websockets.md
@@ -21,6 +21,8 @@ Add WebSocket support to your API to make your routes accessible via Socket.IO i
 - [Available Events](#available-events)
   - [Authentication Events](#authentication-events-1)
 - [Authentication with WebSockets](#authentication-with-websockets)
+- [Server-Side Room Assignment (onConnection)](#server-side-room-assignment-onconnection)
+- [Debug Mode](#debug-mode)
 - [Client Integration](#client-integration)
 - [Best Practices](#best-practices)
 - [Examples](#examples)
@@ -42,9 +44,9 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   
-  // Enable WebSocket support
+  // Enable WebSocket support (recommended form — options object)
   // ⚠️ Also required if you use broadcast-only (no webSocket: true on routes)
-  enableDynamicAPIWebSockets(app);
+  enableDynamicAPIWebSockets(app, { debug: true });
   
   await app.listen(3000);
   console.log('🚀 HTTP Server: http://localhost:3000');
@@ -54,6 +56,15 @@ bootstrap();
 ```
 
 > **Note:** `enableDynamicAPIWebSockets(app)` is required whenever you use **any** WebSocket feature — including broadcasting after HTTP calls — even if no route has `webSocket: true`.
+
+> **⚠️ Deprecated:** The numeric overload `enableDynamicAPIWebSockets(app, 50)` is deprecated and will be removed in v5. Use the options-object form instead:
+> ```typescript
+> // ❌ Deprecated
+> enableDynamicAPIWebSockets(app, 50);
+>
+> // ✅ Recommended
+> enableDynamicAPIWebSockets(app, { maxListeners: 50 });
+> ```
 
 ### Enable WebSockets Globally
 
@@ -1161,7 +1172,9 @@ export const authService = {
 
 ### Authenticating WebSocket Connections
 
-To access protected routes via WebSocket, send the JWT token with the connection:
+To access protected routes via WebSocket, send the JWT token with the connection. Two transport methods are supported:
+
+**✅ Recommended — `auth.token` (Socket.IO handshake `auth` object):**
 
 ```typescript
 import { io } from 'socket.io-client';
@@ -1170,7 +1183,7 @@ const token = localStorage.getItem('accessToken');
 
 const socket = io('http://localhost:3000', {
   auth: {
-    token: token, // Send JWT token with connection
+    token: token, // ✅ Recommended: send JWT token via the auth object
   },
 });
 
@@ -1179,6 +1192,132 @@ socket.emit('auth-get-account', {}, (response) => {
   console.log('Current user:', response.data);
 });
 ```
+
+**⚠️ Deprecated — `query.accessToken` (query string):**
+
+```typescript
+import { io } from 'socket.io-client';
+
+const token = localStorage.getItem('accessToken');
+
+// ⚠️ Deprecated — will be removed in v5
+const socket = io('http://localhost:3000', {
+  query: {
+    accessToken: token,
+  },
+});
+```
+
+> **Note:** The server resolves the token as `socket.handshake.auth.token ?? socket.handshake.query.accessToken`. The `query` method is supported for backward compatibility but exposes the token in URLs and server logs. Always prefer the `auth` object.
+
+---
+
+## Server-Side Room Assignment (onConnection)
+
+The `onConnection` hook lets you run custom logic every time a new WebSocket connection is established — **after** JWT verification. This is ideal for automatically assigning sockets to rooms based on the authenticated user, setting up per-user subscriptions, or logging connections.
+
+**Signature:**
+
+```typescript
+onConnection?: (socket: ExtendedSocket, user?: any) => void | Promise<void>;
+```
+
+- `socket` — the Socket.IO socket instance (extended with `socket.user` if a valid JWT was provided).
+- `user` — the decoded JWT payload (`undefined` if the socket connected without a valid token).
+
+### Example: Auto-join user-specific rooms
+
+```typescript
+// src/main.ts
+import { NestFactory } from '@nestjs/core';
+import { enableDynamicAPIWebSockets } from 'mongodb-dynamic-api';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  enableDynamicAPIWebSockets(app, {
+    debug: true,
+    onConnection: (socket, user) => {
+      if (user) {
+        // Auto-join the user to their personal room
+        socket.join('user-' + user.id);
+
+        // Join a role-based room
+        if (user.role) {
+          socket.join('role-' + user.role);
+        }
+      }
+    },
+  });
+
+  await app.listen(3000);
+}
+bootstrap();
+```
+
+With this setup, you can target broadcasts to specific users or roles using the `rooms` option on your routes:
+
+```typescript
+DynamicApiModule.forFeature({
+  entity: Notification,
+  controllerOptions: { path: 'notifications' },
+  routes: [
+    {
+      type: 'CreateOne',
+      broadcast: {
+        enabled: true,
+        // Broadcast to the targeted user's personal room
+        rooms: (notification) => 'user-' + notification.targetUserId,
+      },
+    },
+  ],
+})
+```
+
+### Example: Async onConnection with logging
+
+```typescript
+enableDynamicAPIWebSockets(app, {
+  onConnection: async (socket, user) => {
+    if (!user) {
+      return; // Anonymous connection — skip room assignment
+    }
+
+    // Async operation: fetch user groups from DB and join rooms
+    const groups = await GroupService.findGroupsByUser(user.id);
+    groups.forEach((group) => socket.join('group-' + group.id));
+  },
+});
+```
+
+> **Note:** If the `onConnection` callback returns a `Promise` that rejects, the error is caught and logged by the adapter — it will **not** disconnect the socket.
+
+---
+
+## Debug Mode
+
+Enable debug mode to get detailed logs from the WebSocket layer. This is useful during development to trace connection events, broadcasts, and room operations.
+
+### Enabling Debug Mode
+
+```typescript
+enableDynamicAPIWebSockets(app, { debug: true });
+```
+
+### What is logged
+
+When `debug: true`, the following events produce log output:
+
+| Component | Log Example | When |
+|-----------|-------------|------|
+| **SocketAdapter** | `[WS] connection – socket=abc123, user=507f...` | Every new socket connection |
+| **SocketAdapter** | `JWT verification failed for socket abc123: jwt expired` | JWT token is invalid or expired |
+| **BroadcastGateway** | `[WS] joinRooms – socket=abc123, rooms=["electronics"]` | Client joins rooms |
+| **BroadcastGateway** | `[WS] leaveRooms – socket=abc123, rooms=["electronics"]` | Client leaves rooms |
+| **BaseGateway** | `[WS] broadcastIfNeeded – event=create-one-product, rooms=["shop"], items=1` | A broadcast is emitted |
+
+> **Tip:** Keep `debug: false` (or omit it) in production to avoid excessive logging.
 
 ---
 
@@ -1928,8 +2067,10 @@ Configure max listeners for the WebSocket server:
 
 ```typescript
 // In main.ts
-enableDynamicAPIWebSockets(app, 50); // Max 50 listeners per event
+enableDynamicAPIWebSockets(app, { maxListeners: 50 }); // Max 50 listeners per event
 ```
+
+> **⚠️ Deprecated:** `enableDynamicAPIWebSockets(app, 50)` still works but will be removed in v5.
 
 ### Event Throttling
 

--- a/README/websockets.md
+++ b/README/websockets.md
@@ -17,6 +17,7 @@ Add WebSocket support to your API to make your routes accessible via Socket.IO i
   - [Broadcasting Events](#broadcasting-events)
     - [Broadcasting for CRUD Routes](#broadcasting-for-crud-routes)
     - [Broadcasting for Auth Routes](#broadcasting-for-auth-routes)
+    - [Room-Targeted Broadcasting](#room-targeted-broadcasting)
 - [Available Events](#available-events)
   - [Authentication Events](#authentication-events-1)
 - [Authentication with WebSockets](#authentication-with-websockets)
@@ -286,6 +287,15 @@ The `broadcast` option accepts an object with the following properties:
 
 - `eventName` (optional): Custom event name for the broadcast. If not specified, uses the same event name pattern as the route (`{route-type}-{displayed-name}`).
 
+- `rooms` (optional): Target specific Socket.IO rooms instead of broadcasting to all connected clients. Can be:
+  - `string` — a single static room name (e.g., `'admin-room'`)
+  - `string[]` — multiple static room names (e.g., `['room-a', 'room-b']`)
+  - `(data: ResponseData) => string | string[]` — a function called **per entity** that dynamically resolves room(s) from the entity data. All resolved rooms are deduplicated.
+
+  When `rooms` is set, only clients that have **joined** those rooms (via the `join-rooms` event) will receive the broadcast. When `rooms` is not set, all connected clients receive the broadcast (default behavior).
+
+  See [Room-Targeted Broadcasting](#room-targeted-broadcasting) for full details and examples.
+
 **Special Note for Delete Routes:**
 
 For `DeleteOne` and `DeleteMany` routes, the broadcasted data contains only the `id` of the deleted entity/entities, not the full entity data (since the entity has been deleted). The `BroadcastAbilityPredicate` receives a minimal object: `{ id: string }`.
@@ -480,6 +490,339 @@ DynamicApiModule.forRoot('mongodb://localhost:27017/myapp', {
 - ❌ `resetPassword` / `changePassword` — not supported
 
 > See the [Broadcasting Auth Events](./authentication.md#broadcasting-auth-events) section in the Authentication documentation for full details, including how to filter fields and the data source for each action.
+
+### Room-Targeted Broadcasting
+
+By default, broadcasts are sent to **all** connected WebSocket clients. With the `rooms` option, you can restrict broadcasts to only the clients that have joined specific [Socket.IO rooms](https://socket.io/docs/v4/rooms/). This is useful when different groups of clients care about different subsets of data (e.g., per-tenant, per-category, per-project).
+
+#### How Rooms Work
+
+1. **Clients join rooms** by emitting `join-rooms` (requires authentication).
+2. **Server broadcasts to rooms** — when `rooms` is configured on a route's `broadcast`, only sockets in the resolved rooms receive the event.
+3. **Clients leave rooms** by emitting `leave-rooms` (requires authentication).
+
+If `rooms` is **not set**, the broadcast falls back to the default behavior (all connected clients).
+
+#### Joining and Leaving Rooms
+
+The broadcast gateway exposes two events for room management. **Both require authentication** (JWT token):
+
+| Event | Payload | Response | Description |
+|-------|---------|----------|-------------|
+| `join-rooms` | `{ rooms: string \| string[] }` | `string[]` — list of joined rooms | Adds the socket to one or more rooms |
+| `leave-rooms` | `{ rooms: string \| string[] }` | `string[]` — list of left rooms | Removes the socket from one or more rooms |
+
+**Client example — joining and leaving rooms:**
+
+```typescript
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: { token: 'my-jwt-access-token' },
+});
+
+// Join a single room
+socket.emit('join-rooms', { rooms: 'electronics' }, (response) => {
+  console.log('Joined rooms:', response);
+  // response.data = ['electronics']
+});
+
+// Join multiple rooms at once
+socket.emit('join-rooms', { rooms: ['electronics', 'gadgets'] }, (response) => {
+  console.log('Joined rooms:', response);
+  // response.data = ['electronics', 'gadgets']
+});
+
+// Leave a room
+socket.emit('leave-rooms', { rooms: 'electronics' }, (response) => {
+  console.log('Left rooms:', response);
+  // response.data = ['electronics']
+});
+
+// ⚠️ Without a valid JWT token, an 'Unauthorized' exception is thrown
+socket.emit('join-rooms', { rooms: 'some-room' });
+// → exception event: { message: 'Unauthorized' }
+```
+
+#### `BroadcastRooms` Type
+
+```typescript
+type BroadcastRooms<T extends object> = string | string[] | ((data: T) => string | string[]);
+```
+
+| Form | Description | Example |
+|------|-------------|---------|
+| `string` | A single static room name — all broadcasts go to this room | `'admin-room'` |
+| `string[]` | Multiple static room names | `['room-a', 'room-b']` |
+| `(data: T) => string \| string[]` | A function called **per entity** in the broadcast payload. Returns the room(s) to target. All results are flattened and deduplicated. | `(item) => item.category` |
+
+#### Static Rooms
+
+Use a fixed room name when all broadcasts for a route should go to the same room, regardless of the entity data:
+
+```typescript
+DynamicApiModule.forFeature({
+  entity: Product,
+  controllerOptions: { path: 'products' },
+  routes: [
+    {
+      type: 'CreateOne',
+      broadcast: {
+        enabled: true,
+        rooms: 'products-room', // All CreateOne broadcasts go to 'products-room'
+      },
+    },
+    {
+      type: 'DeleteOne',
+      broadcast: {
+        enabled: true,
+        rooms: ['watchers', 'inventory-managers'], // Broadcast to multiple rooms
+      },
+    },
+  ],
+})
+```
+
+**Client:**
+
+```typescript
+// Client A — joins the room, will receive broadcasts
+socket.emit('join-rooms', { rooms: 'products-room' }, () => {
+  console.log('Ready to receive product broadcasts');
+});
+
+socket.on('create-one-product', (data) => {
+  console.log('New product (room broadcast):', data);
+});
+
+// Client B — did NOT join 'products-room', will NOT receive the broadcast
+socket.on('create-one-product', (data) => {
+  // ❌ This listener is never called because Client B is not in the room
+});
+```
+
+#### Dynamic Rooms
+
+Use a function to resolve the target room(s) from the entity data at broadcast time. This is ideal when different entities should be broadcast to different rooms:
+
+```typescript
+@Schema({ collection: 'products' })
+class Product extends BaseEntity {
+  @Prop({ type: String, required: true })
+  name: string;
+
+  @Prop({ type: String })
+  category?: string; // 'electronics', 'clothing', 'food', etc.
+}
+
+DynamicApiModule.forFeature({
+  entity: Product,
+  controllerOptions: { path: 'products' },
+  routes: [
+    {
+      type: 'CreateOne',
+      webSocket: true,
+      broadcast: {
+        enabled: true,
+        // Room is resolved from the created entity's category
+        rooms: (product: Product) => product.category ?? 'uncategorized',
+      },
+    },
+    {
+      type: 'UpdateOne',
+      broadcast: {
+        enabled: true,
+        // Can return multiple rooms
+        rooms: (product: Product) => ['all-products', `category-${product.category}`],
+      },
+    },
+  ],
+})
+```
+
+**Client:**
+
+```typescript
+// Client subscribes to the 'electronics' category
+socket.emit('join-rooms', { rooms: 'electronics' }, () => {
+  console.log('Watching electronics');
+});
+
+socket.on('create-one-product', (data) => {
+  console.log('New electronics product:', data);
+  // ✅ Only received if the created product has category === 'electronics'
+});
+
+// Another client subscribes to 'clothing'
+socket.emit('join-rooms', { rooms: 'clothing' }, () => {
+  console.log('Watching clothing');
+});
+// This client will NOT receive broadcasts for electronics products
+```
+
+#### Dynamic Rooms with Multiple Entities
+
+For routes that handle multiple entities (`CreateMany`, `UpdateMany`, `DuplicateMany`, `DeleteMany`), the `rooms` function is called **once per entity**. All resolved rooms are **deduplicated** before broadcasting:
+
+```typescript
+{
+  type: 'CreateMany',
+  broadcast: {
+    enabled: true,
+    rooms: (product: Product) => product.category ?? 'unknown',
+  },
+}
+
+// If CreateMany creates:
+//   [{ name: 'Laptop', category: 'electronics' }, { name: 'T-Shirt', category: 'clothing' }]
+// Resolved rooms = ['electronics', 'clothing'] (deduplicated)
+// The broadcast is sent to BOTH rooms with the full data array
+```
+
+#### Combining `rooms` with `enabled` Predicate
+
+The `enabled` predicate is evaluated **before** rooms are resolved. Only entities that pass the `enabled` check are included in the broadcast payload, and rooms are resolved from **those filtered entities**:
+
+```typescript
+{
+  type: 'UpdateMany',
+  broadcast: {
+    // Step 1: Only published products pass the filter
+    enabled: (product, user) => product.status === 'published',
+    // Step 2: Rooms are resolved from the filtered products only
+    rooms: (product: Product) => product.category ?? 'general',
+    eventName: 'products-published',
+  },
+}
+```
+
+#### Rooms for Auth Routes
+
+Auth broadcast also supports `rooms`:
+
+```typescript
+DynamicApiModule.forRoot('mongodb://localhost:27017/myapp', {
+  useAuth: {
+    userEntity: User,
+    login: {
+      additionalFields: ['role', 'department'],
+      broadcast: {
+        enabled: true,
+        fields: ['id', 'email', 'role', 'department'],
+        rooms: (user) => `department-${user.department}`, // Broadcast login only to same department
+      },
+    },
+    updateAccount: {
+      broadcast: {
+        enabled: true,
+        fields: ['id', 'email', 'name'],
+        rooms: 'admin-dashboard', // Static room for admin watchers
+      },
+    },
+  },
+})
+```
+
+#### Complete Example: Room-Targeted Broadcasting
+
+**Server configuration:**
+
+```typescript
+// src/items/item.entity.ts
+@Schema({ collection: 'items' })
+class Item extends BaseEntity {
+  @Prop({ type: String, required: true })
+  name: string;
+
+  @Prop({ type: String })
+  category?: string;
+}
+
+// src/app.module.ts
+DynamicApiModule.forFeature({
+  entity: Item,
+  controllerOptions: { path: 'items', apiTag: 'Item', isPublic: true },
+  routes: [
+    // WS route + static room
+    {
+      type: 'CreateOne',
+      webSocket: true,
+      broadcast: { enabled: true, rooms: 'items-room' },
+    },
+    // WS route + dynamic room resolved from entity
+    {
+      type: 'UpdateOne',
+      webSocket: true,
+      broadcast: {
+        enabled: true,
+        rooms: (item: Item) => item.category ?? 'unknown',
+      },
+    },
+    // HTTP-only route + static room
+    {
+      type: 'DuplicateOne',
+      broadcast: { enabled: true, rooms: 'items-room' },
+    },
+    // HTTP-only route + dynamic room
+    {
+      type: 'ReplaceOne',
+      broadcast: {
+        enabled: true,
+        rooms: (item: Item) => item.category ?? 'unknown',
+      },
+    },
+  ],
+})
+```
+
+**Client integration:**
+
+```typescript
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: { token: accessToken },
+});
+
+// 1. Join the static room
+socket.emit('join-rooms', { rooms: 'items-room' }, (res) => {
+  console.log('Joined:', res.data); // ['items-room']
+});
+
+// 2. Join a dynamic room (matching a category)
+socket.emit('join-rooms', { rooms: 'electronics' }, (res) => {
+  console.log('Joined:', res.data); // ['electronics']
+});
+
+// 3. Listen for broadcasts
+socket.on('create-one-item', (data) => {
+  console.log('New item (static room):', data);
+  // ✅ Received because we joined 'items-room'
+});
+
+socket.on('update-one-item', (data) => {
+  console.log('Updated item (dynamic room):', data);
+  // ✅ Received only if the updated item has category === 'electronics'
+});
+
+// 4. Create an item via WS — broadcast goes to 'items-room'
+socket.emit('create-one-item', { name: 'Keyboard', category: 'electronics' }, (res) => {
+  console.log('Created:', res.data);
+});
+
+// 5. Or create via HTTP — broadcast still goes to 'items-room'
+await fetch('http://localhost:3000/items', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ name: 'Mouse', category: 'electronics' }),
+});
+
+// 6. Later, leave the room
+socket.emit('leave-rooms', { rooms: 'items-room' }, (res) => {
+  console.log('Left:', res.data); // ['items-room']
+});
+// After leaving, this client no longer receives 'create-one-item' broadcasts
+```
 
 ---
 

--- a/libs/dynamic-api/src/adapters/socket-adapter.spec.ts
+++ b/libs/dynamic-api/src/adapters/socket-adapter.spec.ts
@@ -1,23 +1,147 @@
 import { SocketAdapter } from './socket-adapter';
 import { IoAdapter } from '@nestjs/platform-socket.io';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
+
+jest.mock('jsonwebtoken', () => ({
+  verify: jest.fn(),
+}));
 
 describe('SocketAdapter', () => {
   let adapter: SocketAdapter;
-  const fakeServer = { on: jest.fn() };
+  let connectionHandler: (socket: any) => void;
+
+  const fakeServer = {
+    on: jest.fn((event: string, handler: any) => {
+      if (event === 'connection') {
+        connectionHandler = handler;
+      }
+    }),
+  };
 
   beforeEach(() => {
     adapter = new SocketAdapter();
     jest.spyOn(IoAdapter.prototype, 'createIOServer').mockImplementation(() => fakeServer);
+    DynamicApiWsConfigStore.reset();
+    jest.clearAllMocks();
   });
 
   it('should create', () => {
     expect(adapter).toBeTruthy();
   });
 
-  describe ('createIOServer', () => {
-    it('should create a new server', () => {
+  describe('createIOServer', () => {
+    it('should create a new server and register connection handler', () => {
       const server = adapter.createIOServer(5000);
       expect(server).toStrictEqual(fakeServer);
+      expect(fakeServer.on).toHaveBeenCalledWith('connection', expect.any(Function));
+    });
+
+    it('should reuse the same server on subsequent calls', () => {
+      const server1 = adapter.createIOServer(5000);
+      const server2 = adapter.createIOServer(5000);
+      expect(server1).toBe(server2);
+      expect(IoAdapter.prototype.createIOServer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleConnection (via connection event)', () => {
+    beforeEach(() => {
+      adapter.createIOServer(5000);
+    });
+
+    it('should decode JWT and set user on socket when jwtSecret is set', () => {
+      const jwt = require('jsonwebtoken');
+      jwt.verify.mockReturnValue({ iat: 1, exp: 2, id: 'user-1', name: 'Test' });
+      DynamicApiWsConfigStore.jwtSecret = 'secret';
+
+      const socket = {
+        id: 'sock-1',
+        handshake: { auth: { token: 'tok' }, query: {} },
+      };
+
+      connectionHandler(socket);
+
+      expect(jwt.verify).toHaveBeenCalledWith('tok', 'secret');
+      expect(socket['user']).toEqual({ id: 'user-1', name: 'Test' });
+    });
+
+    it('should not set user when no jwtSecret', () => {
+      const socket = {
+        id: 'sock-2',
+        handshake: { auth: {}, query: {} },
+      };
+
+      connectionHandler(socket);
+
+      expect(socket['user']).toBeUndefined();
+    });
+
+    it('should call onConnection hook if provided', () => {
+      const onConnection = jest.fn();
+      DynamicApiWsConfigStore.onConnection = onConnection;
+
+      const socket = { id: 'sock-3', handshake: { auth: {}, query: {} } };
+
+      connectionHandler(socket);
+
+      expect(onConnection).toHaveBeenCalledWith(socket, undefined);
+    });
+
+    it('should call onConnection with user when JWT is valid', () => {
+      const jwt = require('jsonwebtoken');
+      jwt.verify.mockReturnValue({ iat: 1, exp: 2, id: 'u1' });
+      DynamicApiWsConfigStore.jwtSecret = 'secret';
+      const onConnection = jest.fn();
+      DynamicApiWsConfigStore.onConnection = onConnection;
+
+      const socket = { id: 'sock-4', handshake: { auth: { token: 'tok' }, query: {} } };
+      connectionHandler(socket);
+
+      expect(onConnection).toHaveBeenCalledWith(socket, { id: 'u1' });
+    });
+
+    it('should log debug info when debug is true', () => {
+      DynamicApiWsConfigStore.debug = true;
+      const spyLog = jest.spyOn(adapter['logger'], 'log').mockImplementation(() => {});
+
+      const socket = { id: 'sock-5', handshake: { auth: {}, query: {} } };
+      connectionHandler(socket);
+
+      expect(spyLog).toHaveBeenCalledWith(
+        expect.stringContaining('[WS] connection'),
+      );
+    });
+
+    it('should warn on JWT verification failure when debug is true', () => {
+      const jwt = require('jsonwebtoken');
+      jwt.verify.mockImplementation(() => { throw new Error('bad token'); });
+      DynamicApiWsConfigStore.jwtSecret = 'secret';
+      DynamicApiWsConfigStore.debug = true;
+      const spyWarn = jest.spyOn(adapter['logger'], 'warn').mockImplementation(() => {});
+
+      const socket = { id: 'sock-6', handshake: { auth: { token: 'bad' }, query: {} } };
+      connectionHandler(socket);
+
+      expect(spyWarn).toHaveBeenCalledWith(
+        expect.stringContaining('JWT verification failed'),
+      );
+    });
+
+    it('should catch async onConnection errors', async () => {
+      const error = new Error('hook error');
+      DynamicApiWsConfigStore.onConnection = jest.fn().mockRejectedValue(error);
+      const spyError = jest.spyOn(adapter['logger'], 'error').mockImplementation(() => {});
+
+      const socket = { id: 'sock-7', handshake: { auth: {}, query: {} } };
+      connectionHandler(socket);
+
+      // Wait for the promise rejection to be handled
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(spyError).toHaveBeenCalledWith(
+        expect.stringContaining('onConnection hook error'),
+        expect.any(String),
+      );
     });
   });
 });

--- a/libs/dynamic-api/src/adapters/socket-adapter.ts
+++ b/libs/dynamic-api/src/adapters/socket-adapter.ts
@@ -1,7 +1,11 @@
 import { IoAdapter } from '@nestjs/platform-socket.io';
-import { Server, ServerOptions } from 'socket.io';
+import { Server, ServerOptions, Socket } from 'socket.io';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
+import { ExtendedSocket } from '../interfaces';
+import { MongoDBDynamicApiLogger } from '../logger';
 
 export class SocketAdapter extends IoAdapter {
+  private readonly logger = new MongoDBDynamicApiLogger('SocketAdapter');
   private ioServer: Server | null = null;
 
   createIOServer(
@@ -13,8 +17,49 @@ export class SocketAdapter extends IoAdapter {
   ): Server {
     if (!this.ioServer) {
       this.ioServer = super.createIOServer(port, { ...options, cors: true }) as Server;
+
+      this.ioServer.on('connection', (socket: Socket) => {
+        this.handleConnection(socket as ExtendedSocket);
+      });
     }
 
     return this.ioServer;
+  }
+
+  private handleConnection(socket: ExtendedSocket): void {
+    const { debug, jwtSecret, onConnection } = DynamicApiWsConfigStore;
+    let user: any;
+
+    if (jwtSecret) {
+      const token = (socket.handshake?.auth?.token
+        ?? socket.handshake?.query?.accessToken) as string | undefined;
+
+      if (token) {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const jwt = require('jsonwebtoken');
+          const { iat, exp, ...payload } = jwt.verify(token, jwtSecret);
+          user = payload;
+          socket.user = user;
+        } catch (e) {
+          if (debug) {
+            this.logger.warn(`JWT verification failed for socket ${socket.id}: ${e.message}`);
+          }
+        }
+      }
+    }
+
+    if (debug) {
+      this.logger.log(`[WS] connection – socket=${socket.id}, user=${user?.id ?? 'anonymous'}`);
+    }
+
+    if (onConnection) {
+      const result = onConnection(socket, user);
+      if (result instanceof Promise) {
+        result.catch((err) => {
+          this.logger.error(`onConnection hook error for socket ${socket.id}: ${err.message}`, err.stack);
+        });
+      }
+    }
   }
 }

--- a/libs/dynamic-api/src/builders/route-decorators/auth-decorators.builder.ts
+++ b/libs/dynamic-api/src/builders/route-decorators/auth-decorators.builder.ts
@@ -4,6 +4,7 @@ import { Public } from '../../decorators';
 import { DynamicApiDecoratorBuilder } from '../../interfaces';
 import { JwtAuthGuard } from '../../modules';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 class AuthDecoratorsBuilder implements DynamicApiDecoratorBuilder<any> {
   constructor(
     private readonly isProtected: boolean | undefined,

--- a/libs/dynamic-api/src/builders/route-decorators/route-decorators.builder.ts
+++ b/libs/dynamic-api/src/builders/route-decorators/route-decorators.builder.ts
@@ -7,6 +7,7 @@ import { pascalCase } from '../../helpers';
 import { DynamicApiDecoratorBuilder, RouteType } from '../../interfaces';
 import { BaseEntity } from '../../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 class RouteDecoratorsBuilder<Entity extends BaseEntity> implements DynamicApiDecoratorBuilder<Entity> {
   private readonly responseRouteTypeIsArray: RouteType[] = [
     'GetMany',

--- a/libs/dynamic-api/src/decorators/api-endpoint-visibility.decorator.ts
+++ b/libs/dynamic-api/src/decorators/api-endpoint-visibility.decorator.ts
@@ -1,6 +1,7 @@
 import { applyDecorators, CustomDecorator } from '@nestjs/common';
 import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function ApiEndpointVisibility(
   condition: boolean,
   decorator?: MethodDecorator | CustomDecorator,

--- a/libs/dynamic-api/src/decorators/public.decorator.ts
+++ b/libs/dynamic-api/src/decorators/public.decorator.ts
@@ -1,5 +1,6 @@
 import { SetMetadata } from '@nestjs/common';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 const IS_PUBLIC_KEY = 'isPublic';
 const Public = () => SetMetadata(IS_PUBLIC_KEY, true);
 

--- a/libs/dynamic-api/src/decorators/schema-options.decorator.ts
+++ b/libs/dynamic-api/src/decorators/schema-options.decorator.ts
@@ -1,4 +1,4 @@
-import { DynamicAPISchemaOptionsInterface } from '../interfaces';
+import { DynamicApiSchemaOptionsInterface } from '../interfaces';
 
 /**
  * Metadata key for storing schema options
@@ -7,14 +7,14 @@ import { DynamicAPISchemaOptionsInterface } from '../interfaces';
 const DYNAMIC_API_SCHEMA_OPTIONS_METADATA = 'dynamic-api-module:schema-options';
 
 /**
- * DynamicAPISchemaOptions is a decorator that attaches metadata to a class.
+ * DynamicApiSchemaOptions is a decorator that attaches metadata to a class.
  * The metadata includes options for defining indexes and hooks on a Mongoose schema.
  *
- * @param {DynamicAPISchemaOptionsInterface} options - The options for configuring the schema.
+ * @param {DynamicApiSchemaOptionsInterface} options - The options for configuring the schema.
  * @returns {ClassDecorator} - A class decorator that attaches the provided schema options as metadata to the target class.
  */
-function DynamicAPISchemaOptions(
-  options: DynamicAPISchemaOptionsInterface,
+function DynamicApiSchemaOptions(
+  options: DynamicApiSchemaOptionsInterface,
 ): ClassDecorator {
   return (target: object) => {
     Reflect.defineMetadata(
@@ -25,4 +25,9 @@ function DynamicAPISchemaOptions(
   };
 }
 
-export { DYNAMIC_API_SCHEMA_OPTIONS_METADATA, DynamicAPISchemaOptions };
+/**
+ * @deprecated Use `DynamicApiSchemaOptions` instead. Will be removed in v5.
+ */
+const DynamicAPISchemaOptions = DynamicApiSchemaOptions;
+
+export { DYNAMIC_API_SCHEMA_OPTIONS_METADATA, DynamicApiSchemaOptions, DynamicAPISchemaOptions };

--- a/libs/dynamic-api/src/decorators/validator-pipe.decorator.ts
+++ b/libs/dynamic-api/src/decorators/validator-pipe.decorator.ts
@@ -1,5 +1,6 @@
 import { applyDecorators, UsePipes, ValidationPipe, ValidationPipeOptions } from '@nestjs/common';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function ValidatorPipe(validationPipeOptions?: ValidationPipeOptions): ClassDecorator {
   return validationPipeOptions ? applyDecorators(
     UsePipes(new ValidationPipe(validationPipeOptions)),

--- a/libs/dynamic-api/src/dtos/delete.presenter.ts
+++ b/libs/dynamic-api/src/dtos/delete.presenter.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class DeletePresenter {
   @ApiProperty()
   deletedCount: number;

--- a/libs/dynamic-api/src/dtos/entity.param.ts
+++ b/libs/dynamic-api/src/dtos/entity.param.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class EntityParam implements Pick<BaseEntity, 'id'> {
   @ApiProperty()
   @IsNotEmpty()

--- a/libs/dynamic-api/src/dtos/entity.query.ts
+++ b/libs/dynamic-api/src/dtos/entity.query.ts
@@ -1,1 +1,2 @@
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class EntityQuery {}

--- a/libs/dynamic-api/src/dtos/many-entity.query.ts
+++ b/libs/dynamic-api/src/dtos/many-entity.query.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ArrayMinSize, IsNotEmpty, IsString } from 'class-validator';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class ManyEntityQuery {
   @ApiProperty({ type: [String], minItems: 1 })
   @IsNotEmpty({ each: true })

--- a/libs/dynamic-api/src/filters/ws-exception/dynamic-api-ws-exception.filter.ts
+++ b/libs/dynamic-api/src/filters/ws-exception/dynamic-api-ws-exception.filter.ts
@@ -2,6 +2,7 @@ import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from '@nestjs/co
 import { WsException } from '@nestjs/websockets';
 
 @Catch()
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class DynamicAPIWsExceptionFilter<T> implements ExceptionFilter {
   catch(exception: WsException | HttpException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();

--- a/libs/dynamic-api/src/gateways/base.gateway.spec.ts
+++ b/libs/dynamic-api/src/gateways/base.gateway.spec.ts
@@ -98,6 +98,42 @@ describe('BaseGateway', () => {
 
       expect(socket.user).toEqual(fakeUser);
     });
+
+    it('should set the user to the socket when token is provided via auth.token', () => {
+      socket.handshake.query = {};
+      socket.handshake.auth = { token: accessToken };
+      const isPublic = false;
+      const fakeUser = { id: 'id', name: 'name' };
+      jest.spyOn(DynamicApiModule.state, 'get').mockReturnValue(true);
+      jest.spyOn(jwtService, 'verify').mockReturnValue({
+        iat: Date.now() / 1000,
+        exp: Date.now() / 1000 + 1000,
+        ...fakeUser,
+      });
+
+      gateway['addUserToSocket'](socket, isPublic);
+
+      expect(socket.user).toEqual(fakeUser);
+    });
+
+    it('should prefer auth.token over query.accessToken', () => {
+      const authToken = 'authToken';
+      socket.handshake.query = { accessToken };
+      socket.handshake.auth = { token: authToken };
+      const isPublic = false;
+      const fakeUser = { id: 'id', name: 'name' };
+      jest.spyOn(DynamicApiModule.state, 'get').mockReturnValue(true);
+      const verifySpy = jest.spyOn(jwtService, 'verify').mockReturnValue({
+        iat: Date.now() / 1000,
+        exp: Date.now() / 1000 + 1000,
+        ...fakeUser,
+      });
+
+      gateway['addUserToSocket'](socket, isPublic);
+
+      expect(verifySpy).toHaveBeenCalledWith(authToken, expect.any(Object));
+      expect(socket.user).toEqual(fakeUser);
+    });
   });
 
   describe('isValidManyBody', () => {

--- a/libs/dynamic-api/src/gateways/base.gateway.spec.ts
+++ b/libs/dynamic-api/src/gateways/base.gateway.spec.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { JwtService } from '@nestjs/jwt';
 import { WsException } from '@nestjs/websockets';
 import { DynamicApiModule } from '../dynamic-api.module';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
 import { ExtendedSocket } from '../interfaces';
 import { BaseEntity } from '../models';
 import { BaseGateway } from './base.gateway';
@@ -354,6 +355,36 @@ describe('BaseGateway', () => {
 
         expect(mockSocket.nsp['to']).toHaveBeenCalledWith(['room-a']);
         expect(mockNspToEmit).toHaveBeenCalledWith('custom-event', data);
+      });
+    });
+
+    describe('debug logging', () => {
+      afterEach(() => {
+        DynamicApiWsConfigStore.reset();
+      });
+
+      it('should log event and rooms when debug is true', () => {
+        DynamicApiWsConfigStore.debug = true;
+        const spyLog = jest.spyOn(gateway['logger'], 'log').mockImplementation(() => {});
+        const data = [{ id: '1', name: 'Entity 1' } as Entity];
+        const broadcastConfig = { enabled: true, rooms: 'room-a' };
+
+        gateway['broadcastIfNeeded'](mockSocket, event, data, broadcastConfig);
+
+        expect(spyLog).toHaveBeenCalledWith(
+          expect.stringContaining('[WS] broadcastIfNeeded'),
+        );
+      });
+
+      it('should not log when debug is false', () => {
+        DynamicApiWsConfigStore.debug = false;
+        const spyLog = jest.spyOn(gateway['logger'], 'log').mockImplementation(() => {});
+        const data = [{ id: '1', name: 'Entity 1' } as Entity];
+        const broadcastConfig = { enabled: true };
+
+        gateway['broadcastIfNeeded'](mockSocket, event, data, broadcastConfig);
+
+        expect(spyLog).not.toHaveBeenCalled();
       });
     });
   });

--- a/libs/dynamic-api/src/gateways/base.gateway.ts
+++ b/libs/dynamic-api/src/gateways/base.gateway.ts
@@ -4,6 +4,7 @@ import { isEmpty } from 'lodash';
 import { ManyEntityQuery } from '../dtos';
 import { DynamicApiModule } from '../dynamic-api.module';
 import { resolveRooms } from '../helpers';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
 import { DynamicApiBroadcastConfig, ExtendedSocket } from '../interfaces';
 import { MongoDBDynamicApiLogger } from '../logger';
 import { BaseEntity } from '../models';
@@ -83,6 +84,14 @@ export abstract class BaseGateway<Entity extends BaseEntity> {
 
     const broadcastEvent = eventName || event;
     const resolvedRooms = resolveRooms(rooms, broadcastData);
+
+    if (DynamicApiWsConfigStore.debug) {
+      this.logger.log(
+        `[WS] broadcastIfNeeded – event=${broadcastEvent}, rooms=${
+          resolvedRooms ? JSON.stringify(resolvedRooms) : 'all'
+        }, items=${broadcastData.length}`,
+      );
+    }
 
     if (resolvedRooms) {
       const nsp = socket.nsp;

--- a/libs/dynamic-api/src/gateways/base.gateway.ts
+++ b/libs/dynamic-api/src/gateways/base.gateway.ts
@@ -20,7 +20,8 @@ export abstract class BaseGateway<Entity extends BaseEntity> {
       return;
     }
 
-    const accessToken = socket.handshake.query.accessToken as string;
+    const accessToken = (socket.handshake.auth?.token
+      ?? socket.handshake.query?.accessToken) as string;
     let verified: Partial<Entity> & { iat: number; exp: number; };
 
     if (accessToken) {

--- a/libs/dynamic-api/src/gateways/base.gateway.ts
+++ b/libs/dynamic-api/src/gateways/base.gateway.ts
@@ -9,6 +9,7 @@ import { DynamicApiBroadcastConfig, ExtendedSocket } from '../interfaces';
 import { MongoDBDynamicApiLogger } from '../logger';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export abstract class BaseGateway<Entity extends BaseEntity> {
   private readonly logger = new MongoDBDynamicApiLogger(BaseGateway.name);
 

--- a/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.spec.ts
+++ b/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.spec.ts
@@ -2,6 +2,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { Server } from 'socket.io';
 import { DynamicAPIWsExceptionFilter } from '../filters';
 import { JwtSocketGuard } from '../guards';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
 import { ExtendedSocket } from '../interfaces';
 import { DynamicApiBroadcastService } from '../services';
 import { createDynamicApiBroadcastGateway } from './dynamic-api-broadcast.gateway';
@@ -134,6 +135,52 @@ describe('createDynamicApiBroadcastGateway', () => {
       expect(mockSocket.leave).toHaveBeenCalledWith('room-a');
       expect(mockSocket.leave).toHaveBeenCalledWith('room-b');
       expect(result).toEqual({ event: 'leave-rooms', data: ['room-a', 'room-b'] });
+    });
+  });
+
+  describe('debug logging', () => {
+    afterEach(() => {
+      DynamicApiWsConfigStore.reset();
+    });
+
+    it('should log joinRooms when debug is true', () => {
+      DynamicApiWsConfigStore.debug = true;
+      const GatewayClass = createDynamicApiBroadcastGateway();
+      const gateway = new GatewayClass(mockBroadcastService);
+      const spyLog = jest.spyOn(gateway['logger'], 'log').mockImplementation(() => {});
+      const mockSocket = { id: 'sock-1', join: jest.fn() } as unknown as ExtendedSocket;
+
+      gateway.joinRooms(mockSocket, { rooms: ['room-x'] });
+
+      expect(spyLog).toHaveBeenCalledWith(
+        expect.stringContaining('[WS] joinRooms'),
+      );
+    });
+
+    it('should log leaveRooms when debug is true', () => {
+      DynamicApiWsConfigStore.debug = true;
+      const GatewayClass = createDynamicApiBroadcastGateway();
+      const gateway = new GatewayClass(mockBroadcastService);
+      const spyLog = jest.spyOn(gateway['logger'], 'log').mockImplementation(() => {});
+      const mockSocket = { id: 'sock-2', leave: jest.fn() } as unknown as ExtendedSocket;
+
+      gateway.leaveRooms(mockSocket, { rooms: 'room-y' });
+
+      expect(spyLog).toHaveBeenCalledWith(
+        expect.stringContaining('[WS] leaveRooms'),
+      );
+    });
+
+    it('should not log joinRooms when debug is false', () => {
+      DynamicApiWsConfigStore.debug = false;
+      const GatewayClass = createDynamicApiBroadcastGateway();
+      const gateway = new GatewayClass(mockBroadcastService);
+      const spyLog = jest.spyOn(gateway['logger'], 'log').mockImplementation(() => {});
+      const mockSocket = { id: 'sock-3', join: jest.fn() } as unknown as ExtendedSocket;
+
+      gateway.joinRooms(mockSocket, { rooms: ['room-x'] });
+
+      expect(spyLog).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.ts
+++ b/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.ts
@@ -8,6 +8,7 @@ import { ExtendedSocket, GatewayOptions } from '../interfaces';
 import { MongoDBDynamicApiLogger } from '../logger';
 import { DynamicApiBroadcastService } from '../services';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function createDynamicApiBroadcastGateway(options: GatewayOptions = {}) {
   @WebSocketGateway(options)
   class DynamicApiBroadcastGateway implements OnGatewayInit {

--- a/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.ts
+++ b/libs/dynamic-api/src/gateways/dynamic-api-broadcast.gateway.ts
@@ -3,12 +3,17 @@ import { ConnectedSocket, MessageBody, OnGatewayInit, SubscribeMessage, WebSocke
 import { Server } from 'socket.io';
 import { DynamicAPIWsExceptionFilter } from '../filters';
 import { JwtSocketGuard } from '../guards';
+import { DynamicApiWsConfigStore } from '../helpers/ws-config.store';
 import { ExtendedSocket, GatewayOptions } from '../interfaces';
+import { MongoDBDynamicApiLogger } from '../logger';
 import { DynamicApiBroadcastService } from '../services';
 
 function createDynamicApiBroadcastGateway(options: GatewayOptions = {}) {
   @WebSocketGateway(options)
   class DynamicApiBroadcastGateway implements OnGatewayInit {
+    /** @internal */
+    readonly logger = new MongoDBDynamicApiLogger('DynamicApiBroadcastGateway');
+
     @WebSocketServer()
     readonly server: Server;
 
@@ -30,6 +35,11 @@ function createDynamicApiBroadcastGateway(options: GatewayOptions = {}) {
     ) {
       const roomList = Array.isArray(rooms) ? rooms : [rooms];
       roomList.forEach((room) => socket.join(room));
+
+      if (DynamicApiWsConfigStore.debug) {
+        this.logger.log(`[WS] joinRooms – socket=${socket.id}, rooms=${JSON.stringify(roomList)}`);
+      }
+
       return { event: 'join-rooms', data: roomList };
     }
 
@@ -42,6 +52,11 @@ function createDynamicApiBroadcastGateway(options: GatewayOptions = {}) {
     ) {
       const roomList = Array.isArray(rooms) ? rooms : [rooms];
       roomList.forEach((room) => socket.leave(room));
+
+      if (DynamicApiWsConfigStore.debug) {
+        this.logger.log(`[WS] leaveRooms – socket=${socket.id}, rooms=${JSON.stringify(roomList)}`);
+      }
+
       return { event: 'leave-rooms', data: roomList };
     }
   }

--- a/libs/dynamic-api/src/guards/base-policies.guard.ts
+++ b/libs/dynamic-api/src/guards/base-policies.guard.ts
@@ -7,6 +7,7 @@ import { MongoDBDynamicApiLogger } from '../logger';
 import { BaseEntity } from '../models';
 import { BaseService } from '../services';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 abstract class BasePoliciesGuard<Entity extends BaseEntity> extends BaseService<Entity> implements CanActivate {
   protected routeType: RouteType;
   protected entity: Type<Entity>;
@@ -40,6 +41,7 @@ abstract class BasePoliciesGuard<Entity extends BaseEntity> extends BaseService<
   }
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 abstract class BaseSocketPoliciesGuard<Entity extends BaseEntity> extends BaseService<Entity> implements CanActivate {
   protected routeType: RouteType;
   protected abilityPredicate: AbilityPredicate<Entity> | undefined;

--- a/libs/dynamic-api/src/guards/jwt-socket.guard.spec.ts
+++ b/libs/dynamic-api/src/guards/jwt-socket.guard.spec.ts
@@ -14,9 +14,10 @@ describe('JwtSocketGuard', () => {
     email: 'user@mail.co',
   };
   const query = {};
+  const auth = {};
   const socket = createMock<Socket>({
     id: 'test-socket-id',
-    handshake: { query },
+    handshake: { query, auth },
   });
   const context = createMock<ExecutionContext>({
     getArgs: () => [socket],
@@ -36,6 +37,8 @@ describe('JwtSocketGuard', () => {
   describe('isPublic is false', () => {
     beforeEach(() => {
       guard = new JwtSocketGuard();
+      query['accessToken'] = undefined;
+      auth['token'] = undefined;
     });
 
     it('should be defined', () => {
@@ -50,7 +53,7 @@ describe('JwtSocketGuard', () => {
       expect(typeof guard.canActivate).toBe('function');
     });
 
-    it('should allow access with valid JWT', async () => {
+    it('should allow access with valid JWT via query.accessToken', async () => {
       const accessToken = 'valid.jwt.token';
       query['accessToken'] = accessToken;
       const verifyAsyncSpy = jest.spyOn(JwtService.prototype, 'verifyAsync').mockResolvedValueOnce({
@@ -61,6 +64,40 @@ describe('JwtSocketGuard', () => {
 
       expect(result).toBe(true);
       expect(verifyAsyncSpy).toHaveBeenCalledWith(accessToken, {
+        secret: 'jwtSecret',
+        ignoreExpiration: false,
+      });
+    });
+
+    it('should allow access with valid JWT via auth.token', async () => {
+      const accessToken = 'valid.jwt.token.from.auth';
+      auth['token'] = accessToken;
+      const verifyAsyncSpy = jest.spyOn(JwtService.prototype, 'verifyAsync').mockResolvedValueOnce({
+        user,
+      });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(verifyAsyncSpy).toHaveBeenCalledWith(accessToken, {
+        secret: 'jwtSecret',
+        ignoreExpiration: false,
+      });
+    });
+
+    it('should prefer auth.token over query.accessToken', async () => {
+      const authToken = 'auth.token.value';
+      const queryToken = 'query.token.value';
+      auth['token'] = authToken;
+      query['accessToken'] = queryToken;
+      const verifyAsyncSpy = jest.spyOn(JwtService.prototype, 'verifyAsync').mockResolvedValueOnce({
+        user,
+      });
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      expect(verifyAsyncSpy).toHaveBeenCalledWith(authToken, {
         secret: 'jwtSecret',
         ignoreExpiration: false,
       });

--- a/libs/dynamic-api/src/guards/jwt-socket.guard.ts
+++ b/libs/dynamic-api/src/guards/jwt-socket.guard.ts
@@ -39,13 +39,14 @@ export class JwtSocketGuard implements CanActivate {
   }
 
   private getAccessTokenFromSocketQuery(socket: Socket): string {
-    const accessToken = socket.handshake.query.accessToken as string;
+    const accessToken = socket.handshake.auth?.token
+      ?? socket.handshake.query?.accessToken as string;
     this.logger.debug('getAccessTokenFromSocketQuery', {
       accessToken: !!accessToken,
     });
 
     if (!accessToken) {
-      this.logger.warn('No access token provided in socket query');
+      this.logger.warn('No access token provided in socket auth or query');
       throw new WsException('Unauthorized');
     }
 

--- a/libs/dynamic-api/src/guards/jwt-socket.guard.ts
+++ b/libs/dynamic-api/src/guards/jwt-socket.guard.ts
@@ -6,6 +6,7 @@ import { Socket } from 'socket.io';
 import { DynamicApiModule } from '../dynamic-api.module';
 import { MongoDBDynamicApiLogger } from '../logger';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class JwtSocketGuard implements CanActivate {
   private readonly logger = new MongoDBDynamicApiLogger(JwtSocketGuard.name);
 

--- a/libs/dynamic-api/src/helpers/controller-ability-predicates.helper.ts
+++ b/libs/dynamic-api/src/helpers/controller-ability-predicates.helper.ts
@@ -5,6 +5,7 @@ import {
 } from '../interfaces';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function getPredicateFromControllerAbilityPredicates<Entity extends BaseEntity>(
   controllerAbilityPredicates: ControllerAbilityPredicate<Entity>[],
   route: RouteType): AbilityPredicate<Entity> {

--- a/libs/dynamic-api/src/helpers/format.helper.ts
+++ b/libs/dynamic-api/src/helpers/format.helper.ts
@@ -2,22 +2,27 @@ import { camelCase, upperFirst } from 'lodash';
 import { RouteType } from '../interfaces';
 import { addVersionSuffix } from './versioning-config.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function getNamePrefix(routeType: RouteType, displayedName: string, version: string | undefined): string {
   return `${routeType}${displayedName}${version ? addVersionSuffix(version) : ''}`;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function pascalCase(str?: string) {
   return str ? upperFirst(camelCase(str)) : undefined;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function isValidVersion(version: string) {
   return /^\d+$/.test(version);
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function getDisplayedName(apiTag: string | undefined, entityName: string, subPath: string | undefined) {
   return pascalCase(`${subPath ? subPath + '-' : ''}${apiTag ?? entityName}`);
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function provideName(
   routeType: RouteType,
   displayedName: string,
@@ -27,10 +32,12 @@ function provideName(
   return `${getNamePrefix(routeType, displayedName, version)}${suffix}`;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function isEmptyObject(obj?: unknown): boolean {
   return obj ? typeof obj === 'object' && Object.keys(obj).length === 0 : true;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function isNotEmptyObject(obj?: unknown): boolean {
   return !isEmptyObject(obj);
 }

--- a/libs/dynamic-api/src/helpers/index.ts
+++ b/libs/dynamic-api/src/helpers/index.ts
@@ -10,3 +10,4 @@ export * from './socket-config.helper';
 export * from './swagger-config.helper';
 export * from './validation-config.helper';
 export * from './versioning-config.helper';
+export * from './ws-config.store';

--- a/libs/dynamic-api/src/helpers/mixin-data.helper.ts
+++ b/libs/dynamic-api/src/helpers/mixin-data.helper.ts
@@ -10,6 +10,7 @@ import { BaseEntity } from '../models';
 import { getPredicateFromControllerAbilityPredicates } from './controller-ability-predicates.helper';
 import { getDisplayedName } from './format.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function getMixinData<Entity extends BaseEntity>(
   entity: Type<Entity>,
   {

--- a/libs/dynamic-api/src/helpers/resolve-rooms.helper.ts
+++ b/libs/dynamic-api/src/helpers/resolve-rooms.helper.ts
@@ -8,6 +8,8 @@ import { BroadcastRooms } from '../interfaces';
  *   flattened and deduplicated.
  *
  * Returns `undefined` when `rooms` is not defined (caller should fall back to global broadcast).
+ *
+ * @deprecated Internal API — will be removed from public exports in v5.
  */
 function resolveRooms<T extends object>(
   rooms: BroadcastRooms<T> | undefined,

--- a/libs/dynamic-api/src/helpers/route-decorators.helper.ts
+++ b/libs/dynamic-api/src/helpers/route-decorators.helper.ts
@@ -2,6 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { DynamicApiDecoratorBuilder } from '../interfaces';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function RouteDecoratorsHelper<Entity extends BaseEntity>(
   routeDecorators: DynamicApiDecoratorBuilder<Entity>,
 ) {

--- a/libs/dynamic-api/src/helpers/route-description.helper.ts
+++ b/libs/dynamic-api/src/helpers/route-description.helper.ts
@@ -1,6 +1,7 @@
 import { lowerCase } from 'lodash';
 import { RouteType } from '../interfaces';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function getDefaultRouteDescription(routeType: RouteType, entityName: string): string {
   const contentName = lowerCase(entityName);
 

--- a/libs/dynamic-api/src/helpers/schema.helper.ts
+++ b/libs/dynamic-api/src/helpers/schema.helper.ts
@@ -9,6 +9,7 @@ import { DynamicAPISchemaOptionsInterface, queryByRouteTypeMap } from '../interf
  * It uses the DynamicAPISchemaOptions metadata attached to the entity class to configure the schema.
  * @param {Type} entity - The entity class to build the schema from.
  * @returns {Schema} - The built Mongoose schema.
+ * @deprecated Internal API — will be removed from public exports in v5.
  */
 function buildSchemaFromEntity<Entity>(
   entity: Type<Entity>,

--- a/libs/dynamic-api/src/helpers/socket-config.helper.spec.ts
+++ b/libs/dynamic-api/src/helpers/socket-config.helper.spec.ts
@@ -2,9 +2,14 @@ import { INestApplication } from '@nestjs/common';
 import * as Adapter from '../adapters/socket-adapter';
 import { GatewayOptions } from '../interfaces';
 import { enableDynamicAPIWebSockets, initializeConfigFromOptions } from './socket-config.helper';
+import { DynamicApiWsConfigStore } from './ws-config.store';
 
 jest.mock('../adapters/socket-adapter', () => ({
   SocketAdapter: jest.fn(),
+}));
+
+jest.mock('../dynamic-api.module', () => ({
+  DynamicApiModule: { state: { get: jest.fn().mockReturnValue('test-jwt-secret') } },
 }));
 
 describe('SocketConfigHelper', () => {
@@ -16,15 +21,40 @@ describe('SocketConfigHelper', () => {
 
   beforeEach(() => {
     spySocketAdapter = jest.spyOn(Adapter, 'SocketAdapter');
+    DynamicApiWsConfigStore.reset();
+    jest.clearAllMocks();
   });
 
   describe('enableDynamicAPIWebSockets', () => {
-    it('should call app.useWebSocketAdapter', () => {
+    it('should call app.useWebSocketAdapter with no options', () => {
       enableDynamicAPIWebSockets(fakeApp);
 
       expect(fakeApp.useWebSocketAdapter).toHaveBeenCalledTimes(1);
       expect(spySocketAdapter).toHaveBeenCalledTimes(1);
       expect(spySocketAdapter).toHaveBeenCalledWith(fakeApp);
+      expect(DynamicApiWsConfigStore.debug).toBe(false);
+      expect(DynamicApiWsConfigStore.onConnection).toBeUndefined();
+    });
+
+    it('should accept an options object and populate the config store', () => {
+      const onConnection = jest.fn();
+      enableDynamicAPIWebSockets(fakeApp, { maxListeners: 20, onConnection, debug: true });
+
+      expect(fakeApp.useWebSocketAdapter).toHaveBeenCalledTimes(1);
+      expect(DynamicApiWsConfigStore.debug).toBe(true);
+      expect(DynamicApiWsConfigStore.onConnection).toBe(onConnection);
+      expect(DynamicApiWsConfigStore.jwtSecret).toBe('test-jwt-secret');
+    });
+
+    it('should accept a number (deprecated) and warn', () => {
+      const spyConsoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      enableDynamicAPIWebSockets(fakeApp, 50);
+
+      expect(spyConsoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('Passing a number to enableDynamicAPIWebSockets is deprecated'),
+      );
+      expect(fakeApp.useWebSocketAdapter).toHaveBeenCalledTimes(1);
     });
 
     it('should exit on MaxListenersExceededWarning error', () => {
@@ -39,12 +69,15 @@ describe('SocketConfigHelper', () => {
         process.emit('warning', fakeError as unknown as Error);
       });
 
-      enableDynamicAPIWebSockets(fakeApp, 50);
+      enableDynamicAPIWebSockets(fakeApp, { maxListeners: 50 });
 
       expect(fakeApp.useWebSocketAdapter).toHaveBeenCalledTimes(1);
-      expect(spyConsoleWarn).toHaveBeenNthCalledWith(1, '\nTo fix the MaxListenersExceededWarning, you can increase the maxListeners');
-      expect(spyConsoleWarn).toHaveBeenNthCalledWith(2, 'by passing the value to the enableDynamicAPIWebSockets function as the second argument:\n');
-      expect(spyConsoleWarn).toHaveBeenNthCalledWith(3, '>>> enableDynamicAPIWebSockets(app, 15);\n\n');
+      expect(spyConsoleWarn).toHaveBeenCalledWith(
+        '\nTo fix the MaxListenersExceededWarning, you can increase the maxListeners',
+      );
+      expect(spyConsoleWarn).toHaveBeenCalledWith(
+        '>>> enableDynamicAPIWebSockets(app, { maxListeners: 15 });\n\n',
+      );
       expect(spyProcessExit).toHaveBeenNthCalledWith(1, 1);
     });
   });

--- a/libs/dynamic-api/src/helpers/socket-config.helper.ts
+++ b/libs/dynamic-api/src/helpers/socket-config.helper.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { SocketAdapter } from '../adapters/socket-adapter';
-import { DynamicApiWebSocketOptions, GatewayOptions } from '../interfaces';
+import { DynamicApiWebSocketOptions, DynamicApiWebSocketSetupOptions, GatewayOptions } from '../interfaces';
+import { DynamicApiWsConfigStore } from './ws-config.store';
 
 function initEventsListeners(maxListeners = 10) {
   require('events').EventEmitter.prototype._maxListeners = 100;
@@ -11,16 +12,54 @@ function initEventsListeners(maxListeners = 10) {
 /**
  * Enables WebSocket support for the Nest application.
  * @param {INestApplication} app The Nest application instance.
- * @param maxListeners The maximum number of listeners that can be added to an event.
+ * @param {DynamicApiWebSocketSetupOptions} options Setup options (maxListeners, onConnection, debug).
  */
-function enableDynamicAPIWebSockets(app: INestApplication, maxListeners?: number) {
-  initEventsListeners(maxListeners);
+function enableDynamicAPIWebSockets(app: INestApplication, options?: DynamicApiWebSocketSetupOptions): void;
+/**
+ * Enables WebSocket support for the Nest application.
+ * @param {INestApplication} app The Nest application instance.
+ * @param maxListeners The maximum number of listeners that can be added to an event.
+ * @deprecated Pass an options object instead — `enableDynamicAPIWebSockets(app, { maxListeners })`. Will be removed in v5.
+ */
+function enableDynamicAPIWebSockets(app: INestApplication, maxListeners?: number): void;
+function enableDynamicAPIWebSockets(
+  app: INestApplication,
+  optionsOrMaxListeners?: DynamicApiWebSocketSetupOptions | number,
+): void {
+  let resolvedOptions: DynamicApiWebSocketSetupOptions = {};
+
+  if (typeof optionsOrMaxListeners === 'number') {
+    console.warn(
+      '[DynamicAPI] Passing a number to enableDynamicAPIWebSockets is deprecated. '
+      + 'Use an options object instead: enableDynamicAPIWebSockets(app, { maxListeners: '
+      + optionsOrMaxListeners
+      + ' }). Will be removed in v5.',
+    );
+    resolvedOptions = { maxListeners: optionsOrMaxListeners };
+  } else if (optionsOrMaxListeners) {
+    resolvedOptions = optionsOrMaxListeners;
+  }
+
+  initEventsListeners(resolvedOptions.maxListeners);
+
+  // Populate the static config store
+  DynamicApiWsConfigStore.onConnection = resolvedOptions.onConnection;
+  DynamicApiWsConfigStore.debug = resolvedOptions.debug ?? false;
+
+  // Read jwtSecret from global state (may be undefined when auth is not configured)
+  try {
+    // Lazy-require to avoid circular dependency at module load time
+    const { DynamicApiModule } = require('../dynamic-api.module');
+    DynamicApiWsConfigStore.jwtSecret = DynamicApiModule.state.get('jwtSecret');
+  } catch {
+    // state not yet available – will be resolved later in the adapter
+  }
 
   process.on('warning', function (err) {
     if ('MaxListenersExceededWarning' === err.name) {
       console.warn('\nTo fix the MaxListenersExceededWarning, you can increase the maxListeners');
       console.warn('by passing the value to the enableDynamicAPIWebSockets function as the second argument:\n');
-      console.warn('>>> enableDynamicAPIWebSockets(app, 15);\n\n');
+      console.warn('>>> enableDynamicAPIWebSockets(app, { maxListeners: 15 });\n\n');
       process.exit(1);
     }
   });

--- a/libs/dynamic-api/src/helpers/socket-config.helper.ts
+++ b/libs/dynamic-api/src/helpers/socket-config.helper.ts
@@ -67,6 +67,7 @@ function enableDynamicAPIWebSockets(
   app.useWebSocketAdapter(new SocketAdapter(app));
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function initializeConfigFromOptions(options?: DynamicApiWebSocketOptions): GatewayOptions | undefined {
   if (!options) {
     return;

--- a/libs/dynamic-api/src/helpers/swagger-config.helper.ts
+++ b/libs/dynamic-api/src/helpers/swagger-config.helper.ts
@@ -112,6 +112,7 @@ function buildExtraConfig(
   });
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function enableDynamicAPISwagger(
   app: INestApplication,
   options?: DynamicAPISwaggerOptions,

--- a/libs/dynamic-api/src/helpers/validation-config.helper.ts
+++ b/libs/dynamic-api/src/helpers/validation-config.helper.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function enableDynamicAPIValidation(app: INestApplication, options: ValidationPipeOptions = {}) {
   app.useGlobalPipes(
     new ValidationPipe(options),

--- a/libs/dynamic-api/src/helpers/versioning-config.helper.ts
+++ b/libs/dynamic-api/src/helpers/versioning-config.helper.ts
@@ -1,5 +1,6 @@
 import { INestApplication, VersioningOptions, VersioningType } from '@nestjs/common';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function enableDynamicAPIVersioning(
   app: INestApplication,
   options?: VersioningOptions,
@@ -10,6 +11,7 @@ function enableDynamicAPIVersioning(
   });
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function addVersionSuffix(version?: string) {
   return version ? `V${version}` : '';
 }

--- a/libs/dynamic-api/src/helpers/ws-config.store.spec.ts
+++ b/libs/dynamic-api/src/helpers/ws-config.store.spec.ts
@@ -1,0 +1,45 @@
+import { DynamicApiWsConfigStore } from './ws-config.store';
+
+describe('DynamicApiWsConfigStore', () => {
+  afterEach(() => {
+    DynamicApiWsConfigStore.reset();
+  });
+
+  it('should have default values', () => {
+    expect(DynamicApiWsConfigStore.debug).toBe(false);
+    expect(DynamicApiWsConfigStore.onConnection).toBeUndefined();
+    expect(DynamicApiWsConfigStore.jwtSecret).toBeUndefined();
+  });
+
+  it('should store and retrieve onConnection', () => {
+    const handler = jest.fn();
+    DynamicApiWsConfigStore.onConnection = handler;
+
+    expect(DynamicApiWsConfigStore.onConnection).toBe(handler);
+  });
+
+  it('should store and retrieve debug', () => {
+    DynamicApiWsConfigStore.debug = true;
+
+    expect(DynamicApiWsConfigStore.debug).toBe(true);
+  });
+
+  it('should store and retrieve jwtSecret', () => {
+    DynamicApiWsConfigStore.jwtSecret = 'my-secret';
+
+    expect(DynamicApiWsConfigStore.jwtSecret).toBe('my-secret');
+  });
+
+  it('should reset all values', () => {
+    DynamicApiWsConfigStore.debug = true;
+    DynamicApiWsConfigStore.jwtSecret = 'secret';
+    DynamicApiWsConfigStore.onConnection = jest.fn();
+
+    DynamicApiWsConfigStore.reset();
+
+    expect(DynamicApiWsConfigStore.debug).toBe(false);
+    expect(DynamicApiWsConfigStore.onConnection).toBeUndefined();
+    expect(DynamicApiWsConfigStore.jwtSecret).toBeUndefined();
+  });
+});
+

--- a/libs/dynamic-api/src/helpers/ws-config.store.ts
+++ b/libs/dynamic-api/src/helpers/ws-config.store.ts
@@ -3,6 +3,7 @@ import { ExtendedSocket } from '../interfaces';
 /**
  * Static store for WebSocket configuration values.
  * Populated by `enableDynamicAPIWebSockets` and consumed by the socket adapter and gateways.
+ * @deprecated Internal API — will be removed from public exports in v5.
  */
 export class DynamicApiWsConfigStore {
   static onConnection: ((socket: ExtendedSocket, user?: any) => void | Promise<void>) | undefined;

--- a/libs/dynamic-api/src/helpers/ws-config.store.ts
+++ b/libs/dynamic-api/src/helpers/ws-config.store.ts
@@ -1,0 +1,19 @@
+import { ExtendedSocket } from '../interfaces';
+
+/**
+ * Static store for WebSocket configuration values.
+ * Populated by `enableDynamicAPIWebSockets` and consumed by the socket adapter and gateways.
+ */
+export class DynamicApiWsConfigStore {
+  static onConnection: ((socket: ExtendedSocket, user?: any) => void | Promise<void>) | undefined;
+  static debug = false;
+  static jwtSecret: string | undefined;
+
+  /** Reset all values — useful for testing. */
+  static reset(): void {
+    this.onConnection = undefined;
+    this.debug = false;
+    this.jwtSecret = undefined;
+  }
+}
+

--- a/libs/dynamic-api/src/interceptors/dynamic-api-cache.interceptor.ts
+++ b/libs/dynamic-api/src/interceptors/dynamic-api-cache.interceptor.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { DynamicApiGlobalState } from '../interfaces';
 
 @Injectable()
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class DynamicApiCacheInterceptor extends CacheInterceptor {
   private readonly excludePaths = [
     '/',

--- a/libs/dynamic-api/src/interfaces/dynamic-api-decorator-builder.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-decorator-builder.interface.ts
@@ -1,5 +1,6 @@
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 interface DynamicApiDecoratorBuilder<Entity extends BaseEntity> {
   build(): (ClassDecorator | MethodDecorator)[];
 }

--- a/libs/dynamic-api/src/interfaces/dynamic-api-global-state.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-global-state.interface.ts
@@ -2,11 +2,13 @@ import { GatewayMetadata } from '@nestjs/websockets';
 import { Schema } from 'mongoose';
 import { RouteType } from './dynamic-api-route-type.type';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type Credentials = {
   loginField: string;
   passwordField: string;
 };
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type EntitySchemas<T = any> = {
   [name: string]: Schema<T>;
 }
@@ -16,6 +18,7 @@ type RoutesConfig = {
   defaults: RouteType[];
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 interface DynamicApiGlobalState {
   initialized: boolean;
   uri: string;

--- a/libs/dynamic-api/src/interfaces/dynamic-api-options.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-options.interface.ts
@@ -8,6 +8,7 @@ import { RoutesConfig } from './dynamic-api-global-state.interface';
 import { DynamicAPIRouteConfig } from './dynamic-api-route-config.interface';
 import { DynamicApiWebSocketOptions } from './dynamic-api-web-socket.interface';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 const DYNAMIC_API_GLOBAL_STATE = Symbol('DYNAMIC_API_GLOBAL_STATE');
 
 interface DynamicApiForRootOptions<Entity extends BaseEntity = any> {

--- a/libs/dynamic-api/src/interfaces/dynamic-api-policy-handler.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-policy-handler.interface.ts
@@ -2,11 +2,14 @@ import { ExecutionContext } from '@nestjs/common';
 import { Model } from 'mongoose';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 interface PoliciesGuard {
   canActivate(context: ExecutionContext): boolean | Promise<boolean>;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type PoliciesGuardConstructor<Entity extends BaseEntity> = new (model: Model<Entity>) => PoliciesGuard;
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type AuthPoliciesGuardConstructor = new () => PoliciesGuard;
 
 export { PoliciesGuardConstructor, PoliciesGuard, AuthPoliciesGuardConstructor };

--- a/libs/dynamic-api/src/interfaces/dynamic-api-route-config.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-route-config.interface.ts
@@ -8,7 +8,7 @@ import { DynamicApiServiceBeforeSaveCallback } from './dynamic-api-service-befor
 import { DynamicApiServiceCallback } from './dynamic-api-service-callback.interface';
 import { DynamicApiWebSocketOptions } from './dynamic-api-web-socket.interface';
 
-interface DynamicAPIRouteConfig<Entity extends BaseEntity> {
+interface DynamicApiRouteConfig<Entity extends BaseEntity> {
   type: RouteType;
   isPublic?: boolean;
   description?: string;
@@ -26,4 +26,9 @@ interface DynamicAPIRouteConfig<Entity extends BaseEntity> {
   useInterceptors?: Type<NestInterceptor>[];
 }
 
-export { DynamicAPIRouteConfig };
+/**
+ * @deprecated Use `DynamicApiRouteConfig` instead. Will be removed in v5.
+ */
+type DynamicAPIRouteConfig<Entity extends BaseEntity> = DynamicApiRouteConfig<Entity>;
+
+export { DynamicApiRouteConfig, DynamicAPIRouteConfig };

--- a/libs/dynamic-api/src/interfaces/dynamic-api-route-module.type.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-route-module.type.ts
@@ -12,6 +12,7 @@ import {
   AggregateModule,
 } from '../routes';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type RouteModule =
   CreateManyModule
   | CreateOneModule

--- a/libs/dynamic-api/src/interfaces/dynamic-api-schema-options.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-schema-options.interface.ts
@@ -56,7 +56,7 @@ export const queryByRouteTypeMap: Map<HookEvent, { query: MongoDBQuery, softDele
  * @property {{ fields: IndexDefinition; options?: IndexOptions }[]} indexes - Optional array of index definitions.
  * @property {SchemaHook[]} hooks - Optional array of schema hooks.
  */
-interface DynamicAPISchemaOptionsInterface {
+interface DynamicApiSchemaOptionsInterface {
   indexes?: {
     fields: IndexDefinition;
     options?: IndexOptions;
@@ -65,4 +65,9 @@ interface DynamicAPISchemaOptionsInterface {
   customInit?: (schema: Schema) => void;
 }
 
-export type { SchemaHook, DynamicAPISchemaOptionsInterface };
+/**
+ * @deprecated Use `DynamicApiSchemaOptionsInterface` instead. Will be removed in v5.
+ */
+type DynamicAPISchemaOptionsInterface = DynamicApiSchemaOptionsInterface;
+
+export type { SchemaHook, DynamicApiSchemaOptionsInterface, DynamicAPISchemaOptionsInterface };

--- a/libs/dynamic-api/src/interfaces/dynamic-api-service-provider.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-service-provider.interface.ts
@@ -1,8 +1,13 @@
 import { Type } from '@nestjs/common';
 
-interface DynamicAPIServiceProvider {
+interface DynamicApiServiceProvider {
   provide: string;
   useClass: Type;
 }
 
-export type { DynamicAPIServiceProvider };
+/**
+ * @deprecated Use `DynamicApiServiceProvider` instead. Will be removed in v5.
+ */
+type DynamicAPIServiceProvider = DynamicApiServiceProvider;
+
+export type { DynamicApiServiceProvider, DynamicAPIServiceProvider };

--- a/libs/dynamic-api/src/interfaces/dynamic-api-swagger-options.type.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-swagger-options.type.ts
@@ -6,7 +6,7 @@ import {
   ServerVariableObject,
 } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 
-type DynamicAPISwaggerExtraConfig = {
+type DynamicApiSwaggerExtraConfig = {
   termsOfService?: string;
   contact?: {
     name: string;
@@ -53,14 +53,24 @@ type DynamicAPISwaggerExtraConfig = {
   } | boolean;
 };
 
-type DynamicAPISwaggerOptions = {
+type DynamicApiSwaggerOptions = {
   title?: string;
   description?: string;
   version?: string;
   path?: string;
   jsonFilePath?: string;
-  swaggerExtraConfig?: DynamicAPISwaggerExtraConfig;
+  swaggerExtraConfig?: DynamicApiSwaggerExtraConfig;
   swaggerDocumentOptions?: SwaggerDocumentOptions;
 }
 
-export { DynamicAPISwaggerOptions, DynamicAPISwaggerExtraConfig };
+/**
+ * @deprecated Use `DynamicApiSwaggerExtraConfig` instead. Will be removed in v5.
+ */
+type DynamicAPISwaggerExtraConfig = DynamicApiSwaggerExtraConfig;
+
+/**
+ * @deprecated Use `DynamicApiSwaggerOptions` instead. Will be removed in v5.
+ */
+type DynamicAPISwaggerOptions = DynamicApiSwaggerOptions;
+
+export { DynamicApiSwaggerOptions, DynamicApiSwaggerExtraConfig, DynamicAPISwaggerOptions, DynamicAPISwaggerExtraConfig };

--- a/libs/dynamic-api/src/interfaces/dynamic-api-web-socket.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-web-socket.interface.ts
@@ -12,4 +12,22 @@ type GatewayOptions = GatewayMetadata;
 
 type DynamicApiWebSocketOptions = GatewayOptions | boolean;
 
-export type { DynamicApiWebSocketOptions, ExtendedSocket, GatewayOptions, GatewayResponse };
+/**
+ * Options object accepted by the new `enableDynamicAPIWebSockets(app, options)` overload.
+ */
+interface DynamicApiWebSocketSetupOptions {
+  /** Maximum number of event listeners (defaults to 10). */
+  maxListeners?: number;
+  /** Hook called on every new socket connection after JWT verification. */
+  onConnection?: (socket: ExtendedSocket, user?: any) => void | Promise<void>;
+  /** When `true`, gateways and the socket adapter will emit debug logs. */
+  debug?: boolean;
+}
+
+export type {
+  DynamicApiWebSocketOptions,
+  DynamicApiWebSocketSetupOptions,
+  ExtendedSocket,
+  GatewayOptions,
+  GatewayResponse,
+};

--- a/libs/dynamic-api/src/interfaces/dynamic-api-web-socket.interface.ts
+++ b/libs/dynamic-api/src/interfaces/dynamic-api-web-socket.interface.ts
@@ -6,6 +6,7 @@ interface ExtendedSocket<Entity extends BaseEntity = any> extends Socket {
   user?: Entity;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 type GatewayResponse<Data> = Promise<{ event: string; data: Data }>;
 
 type GatewayOptions = GatewayMetadata;

--- a/libs/dynamic-api/src/logger/mongo-dynamic-api.logger.ts
+++ b/libs/dynamic-api/src/logger/mongo-dynamic-api.logger.ts
@@ -11,6 +11,7 @@ const logLevelsDictionary: Record<MongoDBDynamicApiLoggerMethod, MongoDBDynamicA
   error: ['ERROR', 'WARN', 'INFO', 'DEBUG'],
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class MongoDBDynamicApiLogger extends Logger {
   private readonly isEnabled: boolean = !!process.env.MONGODB_DYNAMIC_API_LOGGER;
   private readonly logLevel: MongoDBDynamicApiLogLevel = (process.env.MONGODB_DYNAMIC_API_LOGGER || 'ERROR') as MongoDBDynamicApiLogLevel;

--- a/libs/dynamic-api/src/mixins/policies-guard.mixin.ts
+++ b/libs/dynamic-api/src/mixins/policies-guard.mixin.ts
@@ -13,6 +13,7 @@ import {
 } from '../interfaces';
 import { BaseEntity } from '../models';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function RoutePoliciesGuardMixin<Entity extends BaseEntity>(
   entity: Type<Entity>,
   routeType: RouteType,
@@ -47,6 +48,7 @@ function RoutePoliciesGuardMixin<Entity extends BaseEntity>(
   return RoutePoliciesGuard;
 }
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 function SocketPoliciesGuardMixin<Entity extends BaseEntity>(
   entity: Type<Entity>,
   routeType: RouteType,

--- a/libs/dynamic-api/src/modules/auth/auth.helper.spec.ts
+++ b/libs/dynamic-api/src/modules/auth/auth.helper.spec.ts
@@ -269,6 +269,69 @@ describe('AuthHelper', () => {
       });
     });
 
+    describe('LocalStrategy authenticate login alias normalization', () => {
+      let strategy: any;
+      let authService: any;
+      const aliasLoginField = 'nickname';
+
+      beforeEach(() => {
+        authService = { validateUser: jest.fn() };
+      });
+
+      it('should map body.login to body[loginField] when loginField is not present', () => {
+        const provider = createLocalStrategyProvider<UserEntity>(aliasLoginField, passwordField, undefined);
+        strategy = new provider.useClass(authService);
+
+        const superAuthenticateSpy = jest.spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        ).mockImplementation(() => {});
+        const req = { body: { login: 'user@test.com', [passwordField]: 'secret' } };
+
+        strategy.authenticate(req);
+
+        expect(req.body[aliasLoginField]).toBe('user@test.com');
+        expect(superAuthenticateSpy).toHaveBeenCalledWith(req, undefined);
+        superAuthenticateSpy.mockRestore();
+      });
+
+      it('should not overwrite body[loginField] when it is already present even if body.login is set', () => {
+        const provider = createLocalStrategyProvider<UserEntity>(aliasLoginField, passwordField, undefined);
+        strategy = new provider.useClass(authService);
+
+        const superAuthenticateSpy = jest.spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        ).mockImplementation(() => {});
+        const req = { body: { [aliasLoginField]: 'original', login: 'alias', [passwordField]: 'secret' } };
+
+        strategy.authenticate(req);
+
+        expect(req.body[aliasLoginField]).toBe('original');
+        superAuthenticateSpy.mockRestore();
+      });
+
+      it('should map body.login to body[loginField] in customValidate path', async () => {
+        const fakeUser = { id: 10 };
+        const customValidate = jest.fn().mockResolvedValueOnce(fakeUser);
+        const provider = createLocalStrategyProvider<UserEntity>(aliasLoginField, passwordField, undefined, customValidate);
+        strategy = new provider.useClass(authService);
+
+        const successFn = jest.fn();
+        const errorFn = jest.fn();
+        strategy.success = successFn;
+        strategy.error = errorFn;
+
+        const req = { body: { login: 'alias@test.com', [passwordField]: 'secret' } };
+        strategy.authenticate(req);
+
+        await new Promise((r) => setImmediate(r));
+
+        expect(req.body[aliasLoginField]).toBe('alias@test.com');
+        expect(successFn).toHaveBeenCalledWith(fakeUser);
+      });
+    });
+
     describe('createLocalStrategyProvider with useStrategy', () => {
       it('should return the provided strategy class directly', () => {
         class CustomStrategy {}

--- a/libs/dynamic-api/src/modules/auth/auth.helper.ts
+++ b/libs/dynamic-api/src/modules/auth/auth.helper.ts
@@ -58,6 +58,10 @@ function createLocalStrategyProvider<Entity extends BaseEntity>(
      * from ever being reached in passwordless flows.
      */
     authenticate(req: any, options?: any) {
+      if (!req.body?.[loginField as string] && req.body?.login != null) {
+        req.body[loginField as string] = req.body.login;
+      }
+
       if (!this.customValidate) {
         return super.authenticate(req, options);
       }

--- a/libs/dynamic-api/src/modules/auth/guards/jwt-socket-auth/jwt-socket-auth.guard.spec.ts
+++ b/libs/dynamic-api/src/modules/auth/guards/jwt-socket-auth/jwt-socket-auth.guard.spec.ts
@@ -61,5 +61,31 @@ describe('JwtSocketAuthGuard', () => {
 
       expect(socket.user).toStrictEqual(fakeUser);
     });
+
+    it('should set user to socket when token is provided via auth.token', async () => {
+      const fakeUser = { id: 'id' };
+      context.getArgs.mockReturnValue([socket]);
+      socket.handshake.query = {};
+      socket.handshake.auth = { token: 'authToken' };
+      verifyAsyncSpy.mockResolvedValue({ ...fakeUser, iat: 1, exp: 2 });
+
+      await guard.canActivate(context);
+
+      expect(socket.user).toStrictEqual(fakeUser);
+      expect(verifyAsyncSpy).toHaveBeenCalledWith('authToken', expect.any(Object));
+    });
+
+    it('should prefer auth.token over query.accessToken', async () => {
+      const fakeUser = { id: 'id' };
+      context.getArgs.mockReturnValue([socket]);
+      socket.handshake.query = { accessToken: 'queryToken' };
+      socket.handshake.auth = { token: 'authToken' };
+      verifyAsyncSpy.mockResolvedValue({ ...fakeUser, iat: 1, exp: 2 });
+
+      await guard.canActivate(context);
+
+      expect(socket.user).toStrictEqual(fakeUser);
+      expect(verifyAsyncSpy).toHaveBeenCalledWith('authToken', expect.any(Object));
+    });
   });
 });

--- a/libs/dynamic-api/src/modules/auth/guards/jwt-socket-auth/jwt-socket-auth.guard.ts
+++ b/libs/dynamic-api/src/modules/auth/guards/jwt-socket-auth/jwt-socket-auth.guard.ts
@@ -27,7 +27,8 @@ export class JwtSocketAuthGuard implements CanActivate {
   }
 
   protected getAccessTokenFromSocketQuery(socket: ExtendedSocket): string {
-    const accessToken = socket.handshake.query.accessToken as string;
+    const accessToken = socket.handshake.auth?.token
+      ?? socket.handshake.query?.accessToken as string;
 
     if (!accessToken) {
       throw new WsException('Unauthorized');

--- a/libs/dynamic-api/src/modules/auth/interfaces/auth-controller.interface.ts
+++ b/libs/dynamic-api/src/modules/auth/interfaces/auth-controller.interface.ts
@@ -9,8 +9,8 @@ import { AuthService, LoginResponse } from './auth-service.interface';
 interface AuthController<Entity extends BaseEntity> {
   login<Body>(req: { user: Entity }, body: Body, res: Response): Promise<LoginResponse>;
   register<Body>(body: Body, res: Response): Promise<LoginResponse>;
-  getAccount(req: { user: Entity }): Promise<Partial<Entity>>;
-  updateAccount<Body>(req: { user: Entity }, body: Body): Promise<Entity>;
+  getAccount(req: { user: Entity; headers: Record<string, string> }): Promise<Partial<Entity>>;
+  updateAccount<Body>(req: { user: Entity; headers: Record<string, string> }, body: Body): Promise<Entity>;
   resetPassword(body: ResetPasswordDto): Promise<void>;
   changePassword(body: ChangePasswordDto): Promise<void>;
   refreshToken(req: { user: Entity; headers: Record<string, string>; cookies: Record<string, string> }, res: Response): Promise<LoginResponse>;

--- a/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.spec.ts
+++ b/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.spec.ts
@@ -100,7 +100,27 @@ describe('AuthControllerMixin', () => {
   });
 
   describe('getAccount', () => {
-    it('should call service getAccount', async () => {
+    it('should decode JWT from authorization header and call service getAccount with decoded user', async () => {
+      const AuthController = AuthControllerMixin(
+        TestEntity,
+        { loginField: 'loginField', passwordField: 'passwordField' },
+        undefined,
+        undefined,
+        undefined,
+      );
+      const decodedUser = { id: 'decoded-id', loginField: 'decoded-login', iat: 1, exp: 9999 };
+      jwtService.decode.mockReturnValueOnce(decodedUser);
+      const controller = new AuthController(service, undefined, jwtService);
+
+      await controller.getAccount({ user: new TestEntity(), headers: { authorization: 'Bearer fake-token' } });
+
+      expect(jwtService.decode).toHaveBeenCalledWith('fake-token');
+      expect(service.getAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'decoded-id', loginField: 'decoded-login' }),
+      );
+    });
+
+    it('should fall back to req.user when jwtService is not available', async () => {
       const AuthController = AuthControllerMixin(
         TestEntity,
         { loginField: 'loginField', passwordField: 'passwordField' },
@@ -111,14 +131,85 @@ describe('AuthControllerMixin', () => {
       const controller = new AuthController(service);
       const user = new TestEntity();
 
-      await controller.getAccount({ user });
+      await controller.getAccount({ user, headers: { authorization: 'Bearer fake-token' } });
+
+      expect(service.getAccount).toHaveBeenCalledWith(user);
+    });
+
+    it('should fall back to req.user when authorization header is missing', async () => {
+      const AuthController = AuthControllerMixin(
+        TestEntity,
+        { loginField: 'loginField', passwordField: 'passwordField' },
+        undefined,
+        undefined,
+        undefined,
+      );
+      const controller = new AuthController(service, undefined, jwtService);
+      const user = new TestEntity();
+
+      await controller.getAccount({ user, headers: {} as Record<string, string> });
+
+      expect(service.getAccount).toHaveBeenCalledWith(user);
+    });
+
+    it('should fall back to req.user when jwtService.decode returns null', async () => {
+      const AuthController = AuthControllerMixin(
+        TestEntity,
+        { loginField: 'loginField', passwordField: 'passwordField' },
+        undefined,
+        undefined,
+        undefined,
+      );
+      jwtService.decode.mockReturnValueOnce(null);
+      const controller = new AuthController(service, undefined, jwtService);
+      const user = new TestEntity();
+
+      await controller.getAccount({ user, headers: { authorization: 'Bearer bad-token' } });
+
+      expect(service.getAccount).toHaveBeenCalledWith(user);
+    });
+
+    it('should fall back to req.user when jwtService.decode throws', async () => {
+      const AuthController = AuthControllerMixin(
+        TestEntity,
+        { loginField: 'loginField', passwordField: 'passwordField' },
+        undefined,
+        undefined,
+        undefined,
+      );
+      jwtService.decode.mockImplementationOnce(() => { throw new Error('decode error'); });
+      const controller = new AuthController(service, undefined, jwtService);
+      const user = new TestEntity();
+
+      await controller.getAccount({ user, headers: { authorization: 'Bearer bad-token' } });
 
       expect(service.getAccount).toHaveBeenCalledWith(user);
     });
   });
 
   describe('updateAccount', () => {
-    it('should call service updateAccount', async () => {
+    it('should decode JWT from authorization header and call service updateAccount with decoded user', async () => {
+      const AuthController = AuthControllerMixin(
+        TestEntity,
+        { loginField: 'loginField', passwordField: 'passwordField' },
+        undefined,
+        undefined,
+        undefined,
+      );
+      const decodedUser = { id: 'decoded-id', loginField: 'decoded-login', iat: 1, exp: 9999 };
+      jwtService.decode.mockReturnValueOnce(decodedUser);
+      const controller = new AuthController(service, undefined, jwtService);
+
+      await controller.updateAccount({ user: new TestEntity(), headers: { authorization: 'Bearer fake-token' } }, {});
+
+      expect(jwtService.decode).toHaveBeenCalledWith('fake-token');
+      expect(service.updateAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'decoded-id', loginField: 'decoded-login' }),
+        {},
+      );
+    });
+
+    it('should fall back to req.user when jwtService is not available', async () => {
       const AuthController = AuthControllerMixin(
         TestEntity,
         { loginField: 'loginField', passwordField: 'passwordField' },
@@ -129,7 +220,7 @@ describe('AuthControllerMixin', () => {
       const controller = new AuthController(service);
       const user = new TestEntity();
 
-      await controller.updateAccount({ user }, {});
+      await controller.updateAccount({ user, headers: { authorization: 'Bearer fake-token' } }, {});
 
       expect(service.updateAccount).toHaveBeenCalledWith(user, {});
     });
@@ -494,7 +585,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.getAccount({ user: fakeUser });
+        await controller.getAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } });
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'auth-get-account-broadcast',
@@ -514,7 +605,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.getAccount({ user: fakeUser });
+        await controller.getAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } });
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'auth-get-account-broadcast',
@@ -534,7 +625,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.getAccount({ user: fakeUser });
+        await controller.getAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } });
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'custom-get-account',
@@ -554,7 +645,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.getAccount({ user: fakeUser });
+        await controller.getAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } });
 
         expect(broadcastService.broadcastFromHttp).not.toHaveBeenCalled();
       });
@@ -571,7 +662,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.updateAccount({ user: fakeUser }, {});
+        await controller.updateAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } }, {});
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'auth-update-account-broadcast',
@@ -590,7 +681,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.updateAccount({ user: fakeUser }, {});
+        await controller.updateAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } }, {});
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'auth-update-account-broadcast',
@@ -609,7 +700,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.updateAccount({ user: fakeUser }, {});
+        await controller.updateAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } }, {});
 
         expect(broadcastService.broadcastFromHttp).toHaveBeenCalledWith(
           'custom-update-account',
@@ -628,7 +719,7 @@ describe('AuthControllerMixin', () => {
         );
         const controller = new AuthController(service, broadcastService, jwtService);
 
-        await controller.updateAccount({ user: fakeUser }, {});
+        await controller.updateAccount({ user: fakeUser, headers: { authorization: 'Bearer fake-token' } }, {});
 
         expect(broadcastService.broadcastFromHttp).not.toHaveBeenCalled();
       });

--- a/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.ts
+++ b/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.ts
@@ -74,7 +74,13 @@ function AuthControllerMixin<Entity extends BaseEntity>(
   class AuthLoginDto extends IntersectionType(
     PickType(userEntity, [loginField]),
     AuthBodyPasswordFieldDto,
-  ) {}
+  ) {
+    @ApiProperty({
+      required: false,
+      description: `Alias for the "${String(loginField)}" field. You may send "login" instead of "${String(loginField)}" to authenticate.`,
+    })
+    login?: string;
+  }
 
   const additionalMandatoryFields: (keyof Entity)[] = [];
   const additionalOptionalFields: (keyof Entity)[] = [];

--- a/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.ts
+++ b/libs/dynamic-api/src/modules/auth/mixins/auth-controller.mixin.ts
@@ -146,14 +146,38 @@ function AuthControllerMixin<Entity extends BaseEntity>(
       @Optional() protected readonly jwtService?: JwtService,
     ) {}
 
+    private extractUserFromToken(req: { headers?: Record<string, string> }): Entity | undefined {
+      if (!this.jwtService) {
+        return undefined;
+      }
+
+      const token = req.headers?.authorization?.split(' ')[1];
+      if (!token) {
+        return undefined;
+      }
+
+      try {
+        const decoded = this.jwtService.decode(token);
+        if (!decoded || typeof decoded === 'string') {
+          return undefined;
+        }
+
+        const { iat, exp, ...userPayload } = decoded as Record<string, unknown>;
+        return userPayload as unknown as Entity;
+      } catch {
+        return undefined;
+      }
+    }
+
     @ApiBearerAuth()
     @UseGuards(JwtAuthGuard)
     @HttpCode(HttpStatus.OK)
     @ApiOkResponse({ type: AuthUserPresenter })
     @UseInterceptors(...getAccountUseInterceptors)
     @Get('account')
-    async getAccount(@Request() req: { user: Entity }) {
-      const account = await this.service.getAccount(req.user);
+    async getAccount(@Request() req: { user: Entity; headers: Record<string, string> }) {
+      const user = this.extractUserFromToken(req) ?? req.user;
+      const account = await this.service.getAccount(user);
 
       if (getAccountBroadcastConfig) {
         const broadcastData = buildAuthBroadcastData(account, getAccountBroadcastConfig.fields);
@@ -253,10 +277,11 @@ function AuthControllerMixin<Entity extends BaseEntity>(
     @UseInterceptors(...updateAccountUseInterceptors)
     @Patch('account')
     async updateAccount(
-      @Request() req: { user: Entity },
+      @Request() req: { user: Entity; headers: Record<string, string> },
       @Body() body: AuthUpdateAccountDto,
     ) {
-      const account = await this.service.updateAccount(req.user, body);
+      const user = this.extractUserFromToken(req) ?? req.user;
+      const account = await this.service.updateAccount(user, body);
 
       if (updateAccountBroadcastConfig) {
         const broadcastData = buildAuthBroadcastData(account, updateAccountBroadcastConfig.fields);

--- a/libs/dynamic-api/src/routes/aggregate/aggregate.module.ts
+++ b/libs/dynamic-api/src/routes/aggregate/aggregate.module.ts
@@ -10,6 +10,7 @@ import {
   createAggregateServiceProvider,
 } from './aggregate.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class AggregateModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/create-many/create-many.module.ts
+++ b/libs/dynamic-api/src/routes/create-many/create-many.module.ts
@@ -11,6 +11,7 @@ import {
   createCreateManyServiceProvider,
 } from './create-many.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class CreateManyModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/create-one/create-one.module.ts
+++ b/libs/dynamic-api/src/routes/create-one/create-one.module.ts
@@ -7,6 +7,7 @@ import { BaseEntity } from '../../models';
 import { DynamicApiBroadcastService } from '../../services';
 import { createCreateOneController, createCreateOneGateway, createCreateOneServiceProvider } from './create-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class CreateOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/delete-many/delete-many.module.ts
+++ b/libs/dynamic-api/src/routes/delete-many/delete-many.module.ts
@@ -11,6 +11,7 @@ import {
   createDeleteManyServiceProvider,
 } from './delete-many.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class DeleteManyModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/delete-one/delete-one.module.ts
+++ b/libs/dynamic-api/src/routes/delete-one/delete-one.module.ts
@@ -11,6 +11,7 @@ import {
   createDeleteOneServiceProvider,
 } from './delete-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class DeleteOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/duplicate-many/duplicate-many.module.ts
+++ b/libs/dynamic-api/src/routes/duplicate-many/duplicate-many.module.ts
@@ -11,6 +11,7 @@ import {
   createDuplicateManyServiceProvider,
 } from './duplicate-many.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class DuplicateManyModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/duplicate-one/duplicate-one.module.ts
+++ b/libs/dynamic-api/src/routes/duplicate-one/duplicate-one.module.ts
@@ -11,6 +11,7 @@ import {
   createDuplicateOneServiceProvider,
 } from './duplicate-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class DuplicateOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/get-many/get-many.module.ts
+++ b/libs/dynamic-api/src/routes/get-many/get-many.module.ts
@@ -6,6 +6,7 @@ import { DynamicApiControllerOptions, DynamicAPIRouteConfig, DynamicApiWebSocket
 import { BaseEntity } from '../../models';
 import { createGetManyController, createGetManyGateway, createGetManyServiceProvider } from './get-many.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class GetManyModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/get-one/get-one.module.ts
+++ b/libs/dynamic-api/src/routes/get-one/get-one.module.ts
@@ -9,6 +9,7 @@ import {
   createGetOneServiceProvider,
 } from './get-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class GetOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/replace-one/replace-one.module.ts
+++ b/libs/dynamic-api/src/routes/replace-one/replace-one.module.ts
@@ -11,6 +11,7 @@ import {
   createReplaceOneServiceProvider,
 } from './replace-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class ReplaceOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/update-many/update-many.module.ts
+++ b/libs/dynamic-api/src/routes/update-many/update-many.module.ts
@@ -11,6 +11,7 @@ import {
   createUpdateManyServiceProvider,
 } from './update-many.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class UpdateManyModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/routes/update-one/update-one.module.ts
+++ b/libs/dynamic-api/src/routes/update-one/update-one.module.ts
@@ -7,6 +7,7 @@ import { BaseEntity } from '../../models';
 import { DynamicApiBroadcastService } from '../../services';
 import { createUpdateOneController, createUpdateOneGateway, createUpdateOneServiceProvider } from './update-one.helper';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 @Module({})
 export class UpdateOneModule {
   static forFeature<Entity extends BaseEntity>(

--- a/libs/dynamic-api/src/services/base/base.service.ts
+++ b/libs/dynamic-api/src/services/base/base.service.ts
@@ -8,6 +8,7 @@ import { BaseEntity, SoftDeletableEntity } from '../../models';
 import { DynamicApiResetPasswordOptions } from '../../modules';
 import { DynamicApiGlobalStateService } from '../dynamic-api-global-state/dynamic-api-global-state.service';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export abstract class BaseService<Entity extends BaseEntity> {
   protected user: unknown;
 

--- a/libs/dynamic-api/src/services/bcrypt/bcrypt.service.ts
+++ b/libs/dynamic-api/src/services/bcrypt/bcrypt.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class BcryptService {
   private readonly saltOrRounds = 10;
 

--- a/libs/dynamic-api/src/services/dynamic-api-broadcast/dynamic-api-broadcast.service.ts
+++ b/libs/dynamic-api/src/services/dynamic-api-broadcast/dynamic-api-broadcast.service.ts
@@ -4,6 +4,7 @@ import { resolveRooms } from '../../helpers';
 import { DynamicApiBroadcastConfig } from '../../interfaces';
 
 @Injectable()
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class DynamicApiBroadcastService {
   private static wsServer: Server | null = null;
 

--- a/libs/dynamic-api/src/services/dynamic-api-global-state/dynamic-api-global-state.service.ts
+++ b/libs/dynamic-api/src/services/dynamic-api-global-state/dynamic-api-global-state.service.ts
@@ -3,6 +3,7 @@ import { Connection, createConnection, Model, Schema } from 'mongoose';
 import { BehaviorSubject } from 'rxjs';
 import { DynamicApiGlobalState, EntitySchemas } from '../../interfaces';
 
+/** @deprecated Internal API — will be removed from public exports in v5. */
 export class DynamicApiGlobalStateService {
   private static readonly initialized$ = new BehaviorSubject<boolean>(false);
   private static readonly entitySchemas$  = new BehaviorSubject<EntitySchemas>({});

--- a/libs/dynamic-api/src/utils/deep-partial.ts
+++ b/libs/dynamic-api/src/utils/deep-partial.ts
@@ -1,0 +1,4 @@
+export type DeepPartial<T> = T extends object ? {
+  [P in keyof T]?: DeepPartial<T[P]>;
+} : T;
+

--- a/libs/dynamic-api/src/utils/deep-patial.ts
+++ b/libs/dynamic-api/src/utils/deep-patial.ts
@@ -1,3 +1,4 @@
-export type DeepPartial<T> = T extends object ? {
-  [P in keyof T]?: DeepPartial<T[P]>;
-} : T;
+/**
+ * @deprecated Use `DeepPartial` from `./deep-partial` instead. Will be removed in v5.
+ */
+export { DeepPartial } from './deep-partial';

--- a/libs/dynamic-api/src/utils/index.ts
+++ b/libs/dynamic-api/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './deep-partial';
 export * from './deep-patial';

--- a/libs/dynamic-api/test/for-root/auth-api-login.e2e-spec.ts
+++ b/libs/dynamic-api/test/for-root/auth-api-login.e2e-spec.ts
@@ -68,6 +68,24 @@ describe('DynamicApiModule forRoot - POST /auth/login with login options (e2e)',
     });
   });
 
+  describe('login alias', () => {
+    it('should login successfully when using "login" alias instead of the configured loginField', async () => {
+      const { username, pass } = admin;
+      const { body, status } = await server.post('/auth/login', { login: username, pass });
+
+      expect(status).toBe(200);
+      expect(body).toHaveProperty('accessToken');
+    });
+
+    it('should not overwrite the configured loginField when both loginField and "login" alias are provided', async () => {
+      const { username, pass } = admin;
+      const { body, status } = await server.post('/auth/login', { username, login: 'wrong@test.com', pass });
+
+      expect(status).toBe(200);
+      expect(body).toHaveProperty('accessToken');
+    });
+  });
+
   describe('passwordField', () => {
     it('should throw an unauthorized exception if passwordField is missing', async () => {
       const { body, status } = await server.post('/auth/login', { username: 'unit' });


### PR DESCRIPTION
- **fix(auth): decode JWT from Authorization header instead of relying on req.user getAccount and updateAccount now extract the user identity by decoding the Bearer token from the Authorization header via jwtService.decode(), falling back to req.user only when the token cannot be decoded. This prevents returning the wrong account when req.user is populated through a database lookup (e.g. by email) rather than from the JWT payload, which could match a different user sharing the same login field.**
  

- **docs(broadcast): add room-targeted broadcasting documentation for CRUD and auth routes**
  - Add rooms option to AuthBroadcastConfig reference table (authentication.md)
  - Add Room-Targeted Auth Broadcasts section with dynamic/static room examples
  - Add comprehensive Room-Targeted Broadcasting section (websockets.md):
    join-rooms/leave-rooms events, BroadcastRooms type reference,
    static rooms, dynamic rooms, multi-entity deduplication,
    combining rooms with enabled predicate, and complete example
  - Update table of contents with Room-Targeted Broadcasting link
  

- **ci(release-it): use conventional commit format for release commits**
  Add git.commitMessage 'chore(release): ${version}' so that release-it generated commits follow the conventionalcommits preset used by the project.
  

- **feat(ws-guards): support auth.token in WebSocket guards Read socket.handshake.auth.token with fallback to socket.handshake.query.accessToken in all WS guards and base gateway. query.accessToken remains supported (non-breaking). Affected files: - jwt-socket.guard.ts - jwt-socket-auth.guard.ts - base.gateway.ts - corresponding spec files with new test cases**
  

- **feat(websockets): add options object, onConnection hook and debug mode to enableDynamicAPIWebSockets - Add DynamicApiWsConfigStore static store (onConnection, debug, jwtSecret) - Add DynamicApiWebSocketSetupOptions interface - Refactor enableDynamicAPIWebSockets with object overload; number signature is @deprecated (will be removed in v5) - SocketAdapter: decode JWT on connection, attach user to socket, call onConnection hook, debug logging - BaseGateway.broadcastIfNeeded: debug log event + resolved rooms - DynamicApiBroadcastGateway joinRooms/leaveRooms: debug log socket.id + rooms - Export ws-config.store from helpers/index - Add and update tests (868/868 passing)**
  

- **feat(auth): add login alias for the login field**
  Allow clients to send { login: value } instead of { [loginField]: value } in the login request body. The alias is resolved in LocalStrategy.authenticate() before credential extraction, so it works with both standard and customValidate flows.
  
  - auth.helper.ts: normalize req.body.login -> req.body[loginField] when loginField is absent
  - auth-controller.mixin.ts: add optional login property on AuthLoginDto with Swagger description
  - auth.helper.spec.ts: add 3 unit tests for alias normalization
  - auth-api-login.e2e-spec.ts: add 2 e2e tests for login alias
  

- **refactor: clean exports — fix typo, add casing aliases, mark internals as deprecated A. Fix deep-patial typo:    - Create deep-partial.ts as canonical source for DeepPartial type    - Re-export from deep-patial.ts with @deprecated JSDoc    - Export deep-partial first in utils/index.ts, keep deep-patial B. Add DynamicApi* casing aliases (non-breaking):    - DynamicApiRouteConfig (deprecate DynamicAPIRouteConfig)    - DynamicApiSwaggerOptions, DynamicApiSwaggerExtraConfig    - DynamicApiSchemaOptionsInterface    - DynamicApiServiceProvider    - DynamicApiSchemaOptions decorator (deprecate DynamicAPISchemaOptions) C. Mark internal API exports with @deprecated JSDoc:    - builders: AuthDecoratorsBuilder, RouteDecoratorsBuilder    - decorators: ApiEndpointVisibility, ValidatorPipe, IS_PUBLIC_KEY    - dtos: ManyEntityQuery, DeletePresenter, EntityParam, EntityQuery    - filters: DynamicAPIWsExceptionFilter    - gateways: BaseGateway, createDynamicApiBroadcastGateway    - guards: BasePoliciesGuard, BaseSocketPoliciesGuard, JwtSocketGuard    - helpers: all except enableDynamicAPIWebSockets, RepositoryHelper, DynamicApiRepository    - interceptors: DynamicApiCacheInterceptor    - logger: MongoDBDynamicApiLogger    - mixins: RoutePoliciesGuardMixin, SocketPoliciesGuardMixin    - services: BaseService, BcryptService, DynamicApiBroadcastService, DynamicApiGlobalStateService    - interfaces: DynamicApiDecoratorBuilder, PoliciesGuardConstructor, AuthPoliciesGuardConstructor,      PoliciesGuard, RouteModule, GatewayResponse, DYNAMIC_API_GLOBAL_STATE,      DynamicApiGlobalState, EntitySchemas, Credentials    - routes: all 12 *Module classes No export * changed in src/index.ts. All deprecated symbols will be removed in v5.**
  

- **docs: update websockets.md and authentication.md (plan 5/5) websockets.md: - Quick Start: show enableDynamicAPIWebSockets(app, { debug: true }) as recommended form - Quick Start: add deprecation note for numeric overload (app, 50) - Authentication with WebSockets: document both handshake forms   (auth: { token } recommended, query: { accessToken } deprecated) - Add new section: Server-Side Room Assignment (onConnection) - Add new section: Debug Mode (what is logged when debug: true) - Performance Considerations: update to options-object form authentication.md: - Login: document body.login alias for loginField - Get Account: add Security Note about req.user derived from JWT,   findOne({ _id: id }), no account mixing - customValidate: detail null = fallback behavior, req.body shape,   body.login alias mapping, bypass of Missing credentials error**
  